### PR TITLE
Remove requirements for logging module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-logging
 requests>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['logging', 'requests>=1.0.0'],
+    install_requires=['requests>=1.0.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Ran into this as well, trying to install CvpRac from pip as well as from source.

logging is built in to current versions of python
Installing with pip causes problems due to old version of logging
being installed.

fixes #35 