### PR TITLE
Fix get_device_by_name to return only the device with the given FQDN

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -275,7 +275,12 @@ class CvpApi(object):
                              'queryparam=%s&startIndex=0&endIndex=0' % fqdn,
                              timeout=self.request_timeout)
         if len(data['netElementList']) > 0:
-            device = data['netElementList'][0]
+            for netElement in data['netElementList']:
+                if netElement['fqdn'] == fqdn:
+                    device = netElement
+                    break
+            else:
+                device = {}
         else:
             device = {}
         return device

--- a/test/system/test_cvp_api.py
+++ b/test/system/test_cvp_api.py
@@ -318,6 +318,13 @@ class TestCvpClient(DutSystemTest):
         self.assertIsNotNone(result)
         self.assertEqual(result, {})
 
+    def test_api_get_device_by_name_substring(self):
+        ''' Verify get_device_by_name with partial fqdn returns nothing
+        '''
+        result = self.api.get_device_by_name(self.device['fqdn'][1:])
+        self.assertIsNotNone(result)
+        self.assertEqual(result, {})
+
     def _create_configlet(self, name, config):
         # Delete the configlet in case it was left by previous test run
         try:


### PR DESCRIPTION
get_device_by_name should ensure that the FQDN of the returned device fully match the parameter.

Before this PR, if a device FQDN is contained in another device FQDN it can't be assured which one is returned.