### PR TITLE
Remove 'id': 1 from _add_temp_action data struct

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -506,8 +506,7 @@ class CvpApi(object):
 
         info = '%s: Configlet Assign: to Device %s' % (app_name, dev['fqdn'])
         info_preview = '<b>Configlet Assign:</b> to Device' + dev['fqdn']
-        data = {'data': [{'id': 1,
-                          'info': info,
+        data = {'data': [{'info': info,
                           'infoPreview': info_preview,
                           'note': '',
                           'action': 'associate',
@@ -582,8 +581,7 @@ class CvpApi(object):
 
         info = '%s Configlet Remove: from Device %s' % (app_name, dev['fqdn'])
         info_preview = '<b>Configlet Remove:</b> from Device' + dev['fqdn']
-        data = {'data': [{'id': 1,
-                          'info': info,
+        data = {'data': [{'info': info,
                           'infoPreview': info_preview,
                           'note': '',
                           'action': 'associate',
@@ -633,8 +631,7 @@ class CvpApi(object):
         '''
         msg = ('%s container %s under container %s' %
                (operation, container_name, parent_name))
-        data = {'data': [{'id': 1,
-                          'info': msg,
+        data = {'data': [{'info': msg,
                           'infoPreview': msg,
                           'action': operation,
                           'nodeType': 'container',
@@ -746,8 +743,7 @@ class CvpApi(object):
         else:
             parent_cont = self.get_parent_container_for_device(device['key'])
             from_id = parent_cont['key']
-        data = {'data': [{'id': 1,
-                          'info': info,
+        data = {'data': [{'info': info,
                           'infoPreview': info,
                           'action': 'update',
                           'nodeType': 'netelement',
@@ -927,8 +923,7 @@ class CvpApi(object):
         self.log.debug('Attempt to apply %s to %s %s' % (image['name'],
                                                          id_type, name))
         info = 'Apply image: %s to %s %s' % (image['name'], id_type, name)
-        data = {'data': [{'id': 1,
-                          'info': info,
+        data = {'data': [{'info': info,
                           'infoPreview': info,
                           'note': '',
                           'action': 'associate',
@@ -995,8 +990,7 @@ class CvpApi(object):
         '''
         self.log.debug('Attempt to remove %s from %s' % (image['name'], name))
         info = 'Remove image: %s from %s' % (image['name'], name)
-        data = {'data': [{'id': 1,
-                          'info': info,
+        data = {'data': [{'info': info,
                           'infoPreview': info,
                           'note': '',
                           'action': 'associate',


### PR DESCRIPTION
The `'id': 1` key/value included in the data dictionaries passed to _add_temp_action causes CVP 2018 to give an error like
```
CvpApiError: POST: https://10.16.129.30:443/web/provisioning/addTempAction.do?format=topology&queryParam=&nodeId=root : Request Error: Input json is not compliant with schema. object instance has properties which are not allowed by the schema: ["id"]
```

It looks like this key is not required in 2017 versions either, but does not cause the failure seen in 2018.

I think this fixes #50, since deploy_device calls several methods that included this key/value in the data structure.

Testing was only done with cloud-deploy deployments for both 2017 and 2018.