### PR TITLE
Finish Python 3 updates

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -31,9 +31,11 @@
 #
 ''' Class containing calls to CVP RESTful API.
 '''
-import json
 import os
-import requests
+# This import is for proper file IO handling support for both Python 2 and 3
+# pylint: disable=redefined-builtin
+from io import open
+
 from cvprac.cvp_client_errors import CvpApiError
 
 try:
@@ -374,11 +376,11 @@ class CvpApi(object):
             self.log.debug('v1 Inventory API Call')
             data = {'data': [
                 {
-                    'containerName' : parent_name,
-                    'containerId' : parent_key,
-                    'containerType' : 'Existing',
-                    'ipAddress' : device_ip,
-                    'containerList' : []
+                    'containerName': parent_name,
+                    'containerId': parent_key,
+                    'containerType': 'Existing',
+                    'ipAddress': device_ip,
+                    'containerList': []
                 }]}
             self.clnt.post('/inventory/add/addToInventory.do?'
                            'startIndex=0&endIndex=0', data=data,
@@ -465,8 +467,9 @@ class CvpApi(object):
             self.get_cvp_info()
         if self.clnt.apiversion == 'v1':
             self.log.debug('v1 Inventory API Call')
-            data = self.clnt.get('/inventory/add/getNonConnectedDeviceCount.do',
-                                 timeout=self.request_timeout)
+            data = self.clnt.get(
+                '/inventory/add/getNonConnectedDeviceCount.do',
+                timeout=self.request_timeout)
             return data['data']
         else:
             self.log.debug('v2 Inventory API Call')
@@ -1254,22 +1257,29 @@ class CvpApi(object):
 
             Args:
                 filepath (str): Local path to the image to upload.
+
+            Returns:
+                data (dict): Dictionary of image add data.
         '''
         # Get the absolute file path to be uploaded
-        imagepath = os.path.abspath(filepath)
-        image = open(imagepath, 'r')
+        image_path = os.path.abspath(filepath)
+        image_data = open(image_path, 'rb')
+        response = self.clnt.post('/image/addImage.do',
+                                  files={'file': image_data})
+        return response
 
-        # Set the request parameters
-        upload_url = '%s/image/addImage.do' % self.clnt.url_prefix
-        kwargs = {}
-        kwargs['cookies'] = self.clnt.cookies
-        kwargs['verify'] = False
+    def cancel_image(self, image_name):
+        ''' Discard/cancel the uploaded image/image bundle before save.
 
-        # Upload the file
-        response = requests.post(upload_url, files={'file': image}, **kwargs)
+            Args:
+                image_name (string): Name of image to cancel/discard.
 
-        # Return the response as a dict
-        return json.loads(response.content)
+            Returns:
+                data (dict): Success or error message.
+        '''
+        image_data = {'data': image_name}
+        return self.clnt.post('/image/cancelImages.do', data=image_data,
+                              timeout=self.request_timeout)
 
     def get_images(self, start=0, end=0):
         ''' Return a list of all images.
@@ -1328,6 +1338,20 @@ class CvpApi(object):
                 return None
             raise error
         return image
+
+    def delete_image_bundle(self, image_key, image_name):
+        ''' Delete image bundle
+
+            Args:
+                image_key (str): The key of the image bundle to be deleted.
+                image_name (str): The name of the image bundle to be deleted.
+        '''
+        bundle_data = {
+            'data': [{'key': image_key,
+                      'name': image_name}]
+        }
+        return self.clnt.post('/image/deleteImageBundles.do', data=bundle_data,
+                              timeout=self.request_timeout)
 
     def save_image_bundle(self, name, images, certified=True):
         ''' Save an image bundle to a cluster.


### PR DESCRIPTION
Fix issues with client that were causing system tests to fail.
Reformat client _make_request to fix Python 3 UnboundLocalError.
Fix system tests to put CVP node under test back into the state it was found in.
Add necessary API modules to allow tests to restore state of CVP node under test.
Assorted other updates for Python 3 support.