### PR TITLE
Add search_configlets method and update version test

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -249,6 +249,22 @@ class CvpApi(object):
         return self.clnt.get('/configlet/getConfigletBuilder.do?id=%s'
                              % c_id, timeout=self.request_timeout)
 
+    def search_configlets(self, query, start=0, end=0):
+        ''' Returns a list of configlets that match a search query.
+
+            Args:
+                query (str): A simple string of text to be matched against
+                    the existing configlets. Not a regex.
+                start (int): Start index for the pagination. Default is 0.
+                end (int): End index for the pagination. If end index is 0
+                    then all the records will be returned. Default is 0.
+        '''
+        self.log.debug('search_configlets: query: %s' % query)
+        return self.clnt.get('/configlet/searchConfiglets.do?'
+                             'queryparam=%s&startIndex=%d&endIndex=%d' %
+                             (qplus(query), start, end),
+                             timeout=self.request_timeout)
+
     def get_configlet_by_name(self, name):
         ''' Returns the configlet with the specified name
 

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -95,6 +95,7 @@ import json
 import logging
 from logging.handlers import SysLogHandler
 from itertools import cycle
+from pkg_resources import parse_version
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, \
@@ -186,32 +187,24 @@ class CvpClient(object):
         self.log.setLevel(getattr(logging, log_level))
 
     def set_version(self, version):
-        '''
+        ''' Set the CVP API version to be used when making api calls.
 
-        :param version:
-        :return:
+            For CVP versions 2018.2 and later, use api version 2.
+
+            Args:
+                version (str): The CVP version in use.
         '''
         self.version = version
-        split_version = version.split('.')
-        self.log.info('Version %s', split_version)
-        # Expect version string to be at least two long
-        # Ex: 2018.2
-        # Ex: 2018.1.4
-        # Ex: 2017.2
-        if len(split_version) > 2:
-            # Set apiversion to v2 for 2018.2 and beyond.
-            if int(split_version[0]) > 2017 and int(split_version[1]) > 1:
-                self.log.info('Setting API version to v2')
-                self.apiversion = 'v2'
-            else:
-                self.log.info('Setting API version to v1')
-                self.apiversion = 'v1'
-        else:
-            # If version is shorter than 2 elements for some reason default
-            # to v2
-            self.log.info('Version has less than 2 elements.'
-                          ' Setting API version to v2')
+        self.log.info('Version %s' % version)
+
+        # Set apiversion to v2 for 2018.2 and beyond, set to v1 for
+        # 2018.1 and previous
+        if parse_version(version) > parse_version('2018.1'):
+            self.log.info('Setting API version to v2')
             self.apiversion = 'v2'
+        else:
+            self.log.info('Setting API version to v1')
+            self.apiversion = 'v1'
 
     def connect(self, nodes, username, password, connect_timeout=10,
                 request_timeout=30, protocol='https', port=None, cert=False):

--- a/test/system/test_cvp_api.py
+++ b/test/system/test_cvp_api.py
@@ -312,6 +312,18 @@ class TestCvpClient(DutSystemTest):
         result = self.api.get_tasks_by_status('BOGUS')
         self.assertIsNotNone(result)
 
+    def test_api_search_configlets(self):
+        ''' Verify search_configlets
+        '''
+        result = self.api.search_configlets('TelemetryBuilder')
+
+        # Make sure at least 1 configlet has been returned as noted
+        # by the 'total' key, and that the data is a list.
+        self.assertIn('total', result)
+        self.assertGreater(result['total'], 0)
+        self.assertIn('data', result)
+        self.assertIsInstance(result['data'], list)
+
     def test_api_get_configlets(self):
         ''' Verify get_configlets
         '''


### PR DESCRIPTION
search_configlets: calls configlet/searchConfiglets.do and returns the result.

Update the set_version method to set the api version to v1 or v2 based on CVP version used. Previous method split the version string and compared each element, so 2019.1 elements were not *both* >2017 and >1, so it applied api v1. Use pkg_resources.parse_version instead, which handles minor versions and even -EFT tags well.