### PR TITLE
Rob configletbuilder

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -655,6 +655,57 @@ class CvpApi(object):
                              timeout=self.request_timeout)
         return data['configletList']
 
+    def add_configlet_builder(self, name, config, draft=False, form=[]):
+        ''' Add a confilget builder and return the key for the configlet builder.
+
+            Args:
+                name (str): Configlet builder name
+                config (str): Python configlet builder code
+                draft (bool): If builder is a draft
+                form (list): Array/list of form data
+                    Parameters:
+                        fieldId (str):
+                        fieldLabel (str):
+                        value (str):
+                        type (str): {
+                            'Text box',
+                            'Text area',
+                            'Drop down',
+                            'Check box',
+                            'Radio button',
+                            'IP address',
+                            'Password'
+                        }
+                        validation:
+                            mandatory (boolean):
+                        helpText (str)
+
+            Returns:
+                key (str): The key for the configlet
+        '''
+        # Convert draft to str
+        if draft:
+            draft = 'true'
+        else:
+            draft = 'false'
+
+        self.log.debug('add_configlet_builder: name: %s config: %s form: %s' % (name, config, form))
+        body = {
+            'name': name,
+            'data': {
+                'formList': form,
+                'main_script': {
+                    'data': config
+                }
+            }
+        }
+        # Create the configlet builder
+        self.clnt.post('/configlet/addConfigletBuilder.do?isDraft=' + draft, data=body, timeout=self.request_timeout)
+
+        # Get the key for the configlet
+        data = self.clnt.get('/configlet/getConfigletByName.do?name=%s' % qplus(name), timeout=self.request_timeout)
+        return data['key']
+
     def add_configlet(self, name, config):
         ''' Add a configlet and return the key for the configlet.
 

--- a/test/system/test_cvp_api.py
+++ b/test/system/test_cvp_api.py
@@ -478,6 +478,57 @@ class TestCvpClient(DutSystemTest):
         result = self.api.get_device_by_name(self.device['fqdn'][1:])
         self.assertIsNotNone(result)
         self.assertEqual(result, {})
+    
+    def _create_configlet_builder(self, name, config, draft, form):
+        # Delete the configlet builder in case it was left by a previous test run
+        try:
+            result = self.api.get_confilget_by_name(name)
+            self.api.delete_configlet(name, result['key'])
+        except CvpApiError:
+            pass
+        
+        # Add the configlet builder
+        key = self.api.add_configlet_builder(name, config, draft, form)
+        self.assertIsNotNone(key)
+        return key
+    
+    def test_api_add_delete_configlet_builder(self):
+        ''' Verify add_configlet_builder and delete_configlet
+        '''
+        name = 'test_configlet_builder'
+        config = '''from cvplibrary import Form
+
+dev_host = Form.getFieldById( 'txt_hostname' ).getValue()
+
+print('hostname {0}'.format(dev_host)
+'''
+        draft = False
+        form = [{
+            'fieldId': 'txt_hostname',
+            'fieldLabel': 'Hostname',
+            'type': 'Text box',
+            'validation': {
+                'mandatory': 'false'
+            },
+            'helpText': 'Hostname for the device'
+        }]
+
+        # Add the configlet builder
+        key = self._create_configlet_builder(name, config, draft, form)
+
+        # Verify the configlet builder was added
+        result = self.api.get_configlet_by_name(name)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['name'], name)
+        self.assertEqual(result['config'], config)
+        self.assertEquat(result['key'], key)
+
+        # Delete the configlet builder
+        self.api.delete_configlet(name, key)
+
+        # Verify the configlet builder was deleted
+        with self.assertRaises(CvpApiError):
+            self.api.get_configlet_by_name(name)
 
     def _create_configlet(self, name, config):
         # Delete the configlet in case it was left by previous test run

--- a/test/system/test_cvp_api.py
+++ b/test/system/test_cvp_api.py
@@ -494,8 +494,10 @@ class TestCvpClient(DutSystemTest):
     
     def test_api_add_delete_configlet_builder(self):
         ''' Verify add_configlet_builder and delete_configlet
+            Will test a configlet builder with form data and without
         '''
         name = 'test_configlet_builder'
+        name2 = 'test_configlet_builder_noform'
         config = '''from cvplibrary import Form
 
 dev_host = Form.getFieldById( 'txt_hostname' ).getValue()
@@ -515,20 +517,33 @@ print('hostname {0}'.format(dev_host)
 
         # Add the configlet builder
         key = self._create_configlet_builder(name, config, draft, form)
+        key2 = self._create_configlet_builder(name2, config, draft)
 
         # Verify the configlet builder was added
+        # Form data
         result = self.api.get_configlet_by_name(name)
         self.assertIsNotNone(result)
         self.assertEqual(result['name'], name)
         self.assertEqual(result['config'], config)
         self.assertEquat(result['key'], key)
 
+        # No Form data
+        result2 = self.api.get_configlet_by_name(name2)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['name'], name2)
+        self.assertEqual(result['config'], config)
+        self.assertEquat(result['key'], key2)
+
         # Delete the configlet builder
         self.api.delete_configlet(name, key)
+        self.api.delete_configlet(name2, key2)
 
         # Verify the configlet builder was deleted
         with self.assertRaises(CvpApiError):
             self.api.get_configlet_by_name(name)
+            
+        with self.assertRaises(CvpApiError):
+            self.api.get_configlet_by_name(name2)
 
     def _create_configlet(self, name, config):
         # Delete the configlet in case it was left by previous test run


### PR DESCRIPTION
Adds a new api call to import configlet builders into CVP.  It will import a configlet builder with form data supplied or none.

Tests will add a CB with form data and without form data.