### PR TITLE
Never fallback to HTTP in case of connection failure

### DIFF
--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -315,18 +315,6 @@ class CvpClient(object):
             self.url_prefix_short = ('https://%s:%d'
                                      % (host, self.port or 443))
             error = self._reset_session()
-            if error and not self.cert:
-                self.log.warning('Failed to connect over https. Potentially'
-                                 ' due to an old version of CVP. Attempting'
-                                 ' fallback to http. Error: %s', error)
-                # Attempt http fallback if no cert file is provided. The
-                # intention here is that a user providing a cert file
-                # forces https.
-                self.url_prefix = ('http://%s:%d/web'
-                                   % (host, self.port or 80))
-                self.url_prefix_short = ('http://%s:%d'
-                                         % (host, self.port or 80))
-                error = self._reset_session()
             if error is None:
                 break
             self.error_msg += '%s: %s\n' % (host, error)

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -186,43 +186,19 @@ class TestClient(unittest.TestCase):
         self.clnt._create_session(all_nodes=True)
         self.assertEqual(self.clnt.url_prefix, url)
 
-    def test_create_session_http_fallback(self):
-        """ Test a failed https connection will attempt to fallback to http.
+    def test_create_session_no_http_fallback(self):
+        """ Test a failed https connection will not attempt to fallback to http.
         """
         self.clnt.port = None
-        url = 'http://1.1.1.1:80/web'
-        self.clnt._reset_session = Mock()
-        self.clnt._reset_session.side_effect = ['Failed to connect via https',
-                                                None]
-        self.clnt._create_session(all_nodes=True)
-        self.assertEqual(self.clnt.url_prefix, url)
-        self.assertEqual(self.clnt.error_msg, '\n')
-
-    def test_create_session_http_fallback_port(self):
-        """ Test http fallback will use a user provided port number.
-        """
-        self.clnt.port = 8888
-        url = 'http://1.1.1.1:8888/web'
-        self.clnt._reset_session = Mock()
-        self.clnt._reset_session.side_effect = ['Failed to connect via https',
-                                                None]
-        self.clnt._create_session(all_nodes=True)
-        self.assertEqual(self.clnt.url_prefix, url)
-        self.assertEqual(self.clnt.error_msg, '\n')
-
-    def test_create_session_no_http_fallback_with_cert(self):
-        """ If user passes a certificate to CvpClient it will only attempt to
-            use https and not fall back to http.
-        """
-        self.clnt.port = None
-        self.clnt.cert = 'cert'
         url = 'https://1.1.1.1:443/web'
         error = '\n1.1.1.1: Failed to connect via https\n'
         self.clnt._reset_session = Mock()
-        self.clnt._reset_session.return_value = 'Failed to connect via https'
+        self.clnt._reset_session.side_effect = ['Failed to connect via https',
+                                                None]
         self.clnt._create_session(all_nodes=True)
         self.assertEqual(self.clnt.url_prefix, url)
         self.assertEqual(self.clnt.error_msg, error)
+
 
     def test_make_request_good(self):
         """ Test request does not raise exception and returns json.


### PR DESCRIPTION
Current code attempts a connection with https, and upon failure (eg: a mistake in the password) falls back to http. As a consequence:
- the initial error (why it failed in the first place) is lost. It makes the investigation process much difficult
- the password is sent unencrypted over the network.

Apparently the initial behavior of "defaulting to http" was a request for users of old CVP versions that were fine configuring their network devices over an unencrypted connection.

Fix it: remove this feature entirely.