### PR TITLE
started to add api method update_configlet_builder

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -1092,6 +1092,32 @@ class CvpApi(object):
         return self.clnt.post('/configlet/updateConfiglet.do', data=body,
                               timeout=self.request_timeout)
 
+    def update_configlet_builder(self, config, key, name, draft=False):
+        ''' Update an existing configlet builder.
+
+            Args:
+                config (str): Contents of the buidler config
+                key: (str): key/id of the configlet builder to be updated
+                name: (str): name of the configlet builder
+                draft (boolean): is update a draft
+        '''
+
+        data = {
+            "name": name,
+            "data": {
+                "main_script": {
+                    "data": config
+                }
+            }
+        }
+
+        self.log.debug('update_configlet_builder: config: {} key: {} name: {} '.format(
+            config, key, name))
+
+        # Update the configlet builder
+        self.clnt.post('/configlet/addConfigletBuilder.do?isDraft={}&id={}&action=save'.format(
+            draft, key), data=data, timeout=self.request_timeout)
+
     def add_note_to_configlet(self, key, note):
         ''' Add a note to a configlet.
 


### PR DESCRIPTION
This is the first time I have made any meaningful contribution to open source so I apologize if I am doing something wrong.
 
I started to add a new API method in order to update configlet builders called update_configlet_builder.  I noticed this was lacking and so far I have been manually doing it with CVP's API in my own scripts..  Simply doing an updateConfiglet API would cause it to be of type static and not builder.  I hope this is helpful

I haven't tested this yet as far as this project goes.  Please feel free to reach out to me or let me know if i messed anything up.