### PR TITLE
cvprac: Mask localhost/127.0.0.1 with node ip for cb scripts

### DIFF
--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -90,6 +90,7 @@ Example:
     >>>
 '''
 
+import os
 import re
 import json
 import logging
@@ -287,6 +288,12 @@ class CvpClient(object):
         # pylint: disable=too-many-arguments
         if not isinstance(nodes, list):
             raise TypeError('nodes argument must be a list')
+
+        for idx in range(len(nodes)):
+            if os.environ.get('CURRENT_NODE_IP') and nodes[idx] in ['127.0.0.1', 'localhost']:
+                # We set this env in script-executor container. Mask localhost or 127.0.0.1
+                # with node IP if this is called from configlet builder scripts.
+                nodes[idx] = os.environ.get('CURRENT_NODE_IP')
 
         self.cert = cert
         self.nodes = nodes


### PR DESCRIPTION
This is required for the existing configlet builder scripts using
cvprac to work with overlays which is a feature of hume (2021.2.0)
The changes are backward compatible.