### PR TITLE
cvp_api: updating info string to tackle backend inconsistent state wh…

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -1725,9 +1725,9 @@ class CvpApi(object):
 
                     Ex: {u'data': {u'status': u'success', u'taskIds': []}}
         '''
-        info = '%s moving device %s to container %s' % (app_name,
-                                                        device['fqdn'],
-                                                        container['name'])
+        info = 'Device Add {} to container {} by {}'.format(device['fqdn'],
+                                                       container['name'],
+                                                       app_name)
         self.log.debug('Attempting to move device %s to container %s'
                        % (device['fqdn'], container['name']))
         if 'parentContainerId' in device:


### PR DESCRIPTION
…en moving devices from the Undefined container

When using the `move_device_to_container` function if the info string does not have `Device Add` words we can end up in a n inconsistent state where before executing the taks to move the device from the Undefined container to a target container, if you go to Network Provisioning, right click on the device and select Manage -- Configlets and then Validate, upon hitting save the UI will throw `Cannot assign configlet, since device is under undefined container` this is because the pending task needs to have `Device Add` in the description. This isn't generally a problem if you follow the flow and execute the task, however if you'd want to manually assign more configlets it won't be possible because of this inconsistent state.
