### PR TITLE
feat(cvp_api): Add support for hostname search in get_device_by_name

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -810,11 +810,12 @@ class CvpApi(object):
                     devices.append(device)
         return devices
 
-    def get_device_by_name(self, fqdn):
+    def get_device_by_name(self, fqdn, search_by_hostname=False):
         ''' Returns the net element device dict for the devices fqdn name.
 
             Args:
-                fqdn (str): Fully qualified domain name of the device.
+                fqdn (str): Fully qualified domain name or hostname of the device.
+                search_field (str): method to search for device: fqdn or hostname.
 
             Returns:
                 device (dict): The net element device dict for the device if
@@ -826,9 +827,14 @@ class CvpApi(object):
         device = {}
         if 'netElementList' in data:
             for netelem in data['netElementList']:
-                if netelem['fqdn'] == fqdn:
-                    device = netelem
-                    break
+                if search_by_hostname:
+                    if netelem['fqdn'] == fqdn:
+                        device = netelem
+                        break
+                else:
+                    if netelem['fqdn'].split(".")[0] == fqdn:
+                        device = netelem
+                        break
         return device
 
     def get_device_by_mac(self, device_mac):


### PR DESCRIPTION
Allow to search device by using hostname part of the FQDN and not the full FQDN field.

Tentative fix for #152 

```python
# Default search using FQDN
device_facts = self.__cv_client.api.get_device_by_name(fqdn=device.fqdn)

# Force to use FQDN to search
device_facts = self.__cv_client.api.get_device_by_name(fqdn=device.fqdn, search_field='fqdn')

# Force to use hostname part of FQDN to search
device_facts = self.__cv_client.api.get_device_by_name(fqdn=device.fqdn, search_field='hostname')
```