### PR TITLE
Some enhancements to the task_retrigger script

### DIFF
--- a/docs/labs/lab06-provisioning/vc_task_retrigger.py
+++ b/docs/labs/lab06-provisioning/vc_task_retrigger.py
@@ -116,3 +116,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/docs/labs/lab06-provisioning/vc_task_retrigger.py
+++ b/docs/labs/lab06-provisioning/vc_task_retrigger.py
@@ -4,39 +4,106 @@
 
 # Example on how to re-trigger task creation if a config push task was previously
 # cancelled and the device is still config out of sync
-
-from cvprac.cvp_client import CvpClient
+import argparse
 import ssl
-ssl._create_default_https_context = ssl._create_unverified_context
+import sys
+from getpass import getpass
+from cvprac.cvp_client import CvpClient
+
+
+if ((sys.version_info.major == 3) or
+    (sys.version_info.major == 2 and sys.version_info.minor == 7 and sys.version_info.micro >= 5)):
+    ssl._create_default_https_context = ssl._create_unverified_context
+
 import requests.packages.urllib3
 requests.packages.urllib3.disable_warnings()
 
-# Create connection to CloudVision
-clnt = CvpClient()
 
-clnt.connect(nodes=['cvp1'], username="username",password="password")
 
-# Trigger tasks after they were cancelled
 
-devices = ["tp-avd-leaf1", "tp-avd-leaf2", "tp-avd-leaf3", "tp-avd-leaf4", "tp-avd-spine1", "tp-avd-spine2"]
+def main():
+        
+    compliance = {"0001": "Config is out of sync",
+        "0003": "Config & image out of sync",
+#        "0004": "Config, Image and Device time are in sync",
+        "0005": "Device is not reachable",
+        "0008": "Config, Image and Extensions are out of sync",
+        "0009": "Config and Extensions are out of sync",
+        "0012": "Config, Image, Extension and Device time are out of sync",
+        "0013": "Config, Image and Device time are out of sync",
+        "0014": "Config, Extensions and Device time are out of sync",
+        "0016": "Config and Device time are out of sync"
+    }
+    # Create connection to CloudVision
+    clnt = CvpClient()
 
-compliance = {"0001": "Config is out of sync",
-              "0003": "Config & image out of sync",
-              "0004": "Config, Image and Device time are in sync",
-              "0005": "Device is not reachable",
-              "0008": "Config, Image and Extensions are out of sync",
-              "0009": "Config and Extensions are out of sync",
-              "0012": "Config, Image, Extension and Device time are out of sync",
-              "0013": "Config, Image and Device time are out of sync",
-              "0014": "Config, Extensions and Device time are out of sync",
-              "0016": "Config and Device time are out of sync",
-}
 
-for dev in devices:
-   # generate device object
-   device = clnt.api.get_device_by_name(dev)
-   # generate configlet list
-   cl = clnt.api.get_configlets_by_device_id(device['systemMacAddress'])
-   # generate a task if config is out of sync
-   if device['complianceCode'] in compliance.keys():
-      print(clnt.api.apply_configlets_to_device("", device, cl))
+    parser = argparse.ArgumentParser(description='Script to recreate a task, if a previous config push was cancelled')
+    parser.add_argument('-u', '--username', default='username')
+    parser.add_argument('-p', '--password', default=None)
+    parser.add_argument('-c', '--cvpserver', action='append')
+    parser.add_argument('-f', '--filter', action='append', default=None)
+    args = parser.parse_args()
+
+
+    if args.password is None:
+        args.password = getpass()
+
+    for cvpserver in args.cvpserver:
+        print("Connecting to %s" % cvpserver)
+        try:
+            clnt.connect(nodes=[cvpserver], username=args.username, password=args.password)
+        except Exception as e:
+            print("Unable to connect to CVP: %s" % str(e))
+        #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # Trigger compliance check here
+        #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
+        try:
+            clnt.api.check_compliance('root', 'container')
+        except:
+            # Bad practice, but the check compliance applied to a container can't actually work
+            # since the complianceIndication  key doesn't exist on the container level
+            pass
+
+
+        device_filters = []
+        if args.filter is not None:
+            for entry in args.filter:
+                device_filters.extend(entry.split(','))
+
+        # Get inventory
+        print("Collecting inventory...")
+        devices = clnt.api.get_inventory()
+        print("%d devices in inventory" % len(devices) )
+
+        #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+        for switch in devices:
+            if switch['status'] == 'Registered' and switch['parentContainerId'] != 'undefined_container':
+                # generate device object
+                host = clnt.api.get_device_by_name(switch['hostname'])
+
+                if len(device_filters) > 0:
+                # iterate over device filters, and update task for any devices not in compliance
+                    for filter_term in device_filters:
+                        if filter_term in host:
+                            # generate configlet list
+                            cl = clnt.api.get_configlets_by_device_id(switch['systemMacAddress'])
+                            # generate a task if config is out of sync
+                            if switch['complianceCode'] in compliance.keys():
+                                print(clnt.api.apply_configlets_to_device("", switch, cl))
+                        else:
+                            print("Skipping %s" % host)
+                else:
+                    cl = clnt.api.get_configlets_by_device_id(switch['systemMacAddress'])
+                    # generate a task if config is out of sync
+                    if switch['complianceCode'] in compliance.keys():
+                        print(clnt.api.apply_configlets_to_device("", switch, cl))
+
+            else:
+                print("Skipping %s, device is unregisted for provisioning" % switch['hostname'])
+
+    return 0
+
+if __name__ == "__main__":
+    main()

--- a/docs/labs/lab06-provisioning/vc_task_retrigger.py
+++ b/docs/labs/lab06-provisioning/vc_task_retrigger.py
@@ -80,21 +80,24 @@ def main():
 
         for switch in devices:
             if switch['status'] == 'Registered' and switch['parentContainerId'] != 'undefined_container':
-                # generate device object
-                host = clnt.api.get_device_by_name(switch['hostname'])
 
                 if len(device_filters) > 0:
                 # iterate over device filters, and update task for any devices not in compliance
+                    
                     for filter_term in device_filters:
-                        if filter_term in host:
+                        print("Checking device: %s" % switch['hostname'])
+                        if filter_term in switch['hostname']:
                             # generate configlet list
                             cl = clnt.api.get_configlets_by_device_id(switch['systemMacAddress'])
                             # generate a task if config is out of sync
                             if switch['complianceCode'] in compliance.keys():
                                 print(clnt.api.apply_configlets_to_device("", switch, cl))
+                            else:
+                                print("%s is compliant, nothing to do" % switch['hostname'])
                         else:
-                            print("Skipping %s" % host)
+                            print("Skipping %s due to filter" % switch['hostname'])
                 else:
+                    print("Checking device: %s" % switch['hostname'])
                     cl = clnt.api.get_configlets_by_device_id(switch['systemMacAddress'])
                     # generate a task if config is out of sync
                     if switch['complianceCode'] in compliance.keys():


### PR DESCRIPTION
Added some things (listed below) to make the script more general purpose;
- Accepts arguments for username, password and cvp servers
- Handles unverified context for older python versions
- Triggers a compliance check at the beginning (may require a delay?)
- Won't attempt task generation for unregistered devices or devices in the undefined container
- Allows for string match filtering of the devices its going to try and update
