### PR TITLE
Add cc rapi

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2943,8 +2943,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
-                                 ' from 2021.2.0 or newer.')
+                self.log.warning('Tag.V2 Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(tag_url))
         return self.clnt.post(tag_url, data=payload)
@@ -2975,9 +2974,10 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + tag_url + ' ' + str(payload))
-                return self.clnt.post(tag_url, data=payload)
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('Tag.V2 Resource APIs are supported from 2021.2.0 or newer.')
+                return None
+        self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
 
     def get_tag_assignment_edits(self, workspace_id):
@@ -3007,8 +3007,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Tag.V2 Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
@@ -3048,8 +3047,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Tag.V2 Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {} '.format(tag_url) + str(payload))
         return self.clnt.post(tag_url, data=payload)
@@ -3097,8 +3095,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Tag.V2 Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {} '.format(tag_url) + str(payload))
         return self.clnt.post(tag_url, data=payload)
@@ -3116,8 +3113,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                    self.log.warning('get_all_workspaces: Workspace Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                    self.log.warning('Workspace Resource APIs are supported from 2021.2.0 or newer.')
                     return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.post(url, data=payload)
@@ -3134,8 +3130,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('get_workspace: Workspace Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Workspace Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.get(url)
@@ -3186,8 +3181,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('workspace_config: Workspace Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Workspace Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload)
@@ -3211,8 +3205,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('workspace_build_status: Workspace Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Workspace Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url+params))
         return self.clnt.get(url, timeout=self.request_timeout)
@@ -3247,11 +3240,17 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_get_one: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url))
-        return self.clnt.get(url, timeout=self.request_timeout)
+        try:
+            response = self.clnt.get(url, timeout=self.request_timeout)
+        except Exception as error:
+            if 'resource not found' in str(error):
+                self.log.error('Change Control ID does not exist!')
+                return None
+            raise error
+        return response
 
 
     def change_control_get_all(self):
@@ -3267,8 +3266,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_get_all: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.get(url, timeout=self.request_timeout)
@@ -3298,20 +3296,16 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_approval_get_one: Change Control Resource APIs are supported'
-                                    ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
-        try:
-            cc_status = self.change_control_get_one(cc_id)
-        except Exception as e:
-            self.log.warning('change_control_get_one: The change control ID does not exist.')
+        cc_status = self.change_control_get_one(cc_id)
+        if cc_status is None:
             return None
         if 'approve' not in cc_status['value']:
-            self.log.warning("change_control_approval_get_one: The change has not been approved yet."
-                                " A change has to be approved at least once for the 'approve' state to be populated.")
+            self.log.warning("The change has not been approved yet."
+                             " A change has to be approved at least once for the 'approve' state to be populated.")
             return None
         return self.clnt.get(url, timeout=self.request_timeout)
-
 
 
     def change_control_approval_get_all(self):
@@ -3328,11 +3322,11 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_approval_get_all: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.get(url, timeout=self.request_timeout)
+
 
     def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
@@ -3346,11 +3340,16 @@ class CvpApi(object):
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        try:
-            version = self.change_control_get_one(cc_id)['value']['change']['time']
-        except Exception as e:
-            version = None
+        # try:
+        #     version = self.change_control_get_one(cc_id)['value']['change']['time']
+        # except Exception as e:
+        #     version = None
+        #     return None
+        cc_status = self.change_control_get_one(cc_id)
+        if cc_status is None:
             return None
+        if 'value' in cc_status and 'change' in cc_status['value'] and 'time' in cc_status['value']['change']:
+            version = cc_status['value']['change']['time']
         payload = {
             "key": {
                 "id": cc_id
@@ -3378,8 +3377,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_delete: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.delete(url, timeout=self.request_timeout)
@@ -3491,16 +3489,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_create_with_custom_stages: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload)
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
+                return None
+        self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload)
+
 
     def change_control_create_for_tasks(self, cc_id, name, tasks, series=True):
         ''' Create a simple Change Control for tasks using Resource APIs.
@@ -3548,11 +3542,11 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_create_for_tasks: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
 
     def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
@@ -3580,8 +3574,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_start: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
@@ -3614,8 +3607,7 @@ class CvpApi(object):
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
             if self.clnt.apiversion < 6.0:
-                self.log.warning('change_control_stop: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
+                self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
                 return None
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
@@ -3651,8 +3643,7 @@ class CvpApi(object):
     #         if self.clnt.apiversion is None:
     #             self.get_cvp_info()
     #         if self.clnt.apiversion < 7.0:
-    #             self.log.warning('change_control_schedule: Change Control Resource APIs are supported'
-    #                                  ' from 2021.2.0 or newer.')
+    #             self.log.warning('Change Control Resource APIs are supported from 2021.2.0 or newer.')
     #             return None
     #     self.log.debug('v7 ' + str(url) + ' ' + str(payload))
     #     return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3252,6 +3252,7 @@ class CvpApi(object):
 
     def change_control_get_one(self, cc_id, cc_time=None):
         ''' Get the configuration and status of a change control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Args:
                cc_id (str): The ID of the change control.
@@ -3288,6 +3289,7 @@ class CvpApi(object):
 
     def change_control_get_all(self):
         ''' Get the configuration and status of all Change Controls using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Returns:
                response (dict): A dict that contains a list of all Change Controls.
@@ -3311,6 +3313,7 @@ class CvpApi(object):
 
     def change_control_approval_get_one(self, cc_id, cc_time=None):
         ''' Get the state of a specific Change Control's approve config using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Args:
                cc_id (str): The ID of the change control.
@@ -3348,6 +3351,7 @@ class CvpApi(object):
 
     def change_control_approval_get_all(self):
         ''' Get state information for all Change Control Approvals using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Returns:
                response (dict): A dict that contains a list of all Change Control Approval Configs.
@@ -3371,6 +3375,7 @@ class CvpApi(object):
 
     def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Args:
               cc_id (str): The ID of the change control.
@@ -3396,6 +3401,7 @@ class CvpApi(object):
 
     def change_control_delete(self, cc_id):
         ''' Delete a pending Change Control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
             Args:
               cc_id (str): The ID of the change control.
@@ -3418,6 +3424,8 @@ class CvpApi(object):
 
     def change_control_create_with_custom_stages(self, custom_cc=None):
         ''' Create a Change Control with custom stage hierarchy using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
+
             Args:
                 custom_cc (dict): A dictionary with the entire stage hierarchy.
                 Ex1: {'key': {'id': '409b94d1-c0cb-4d74-8f88-89f66f13f109'},
@@ -3533,6 +3541,8 @@ class CvpApi(object):
 
     def change_control_create_for_tasks(self, cc_id, name, tasks, series=True):
         ''' Create a simple Change Control for tasks using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
+
             This function will create a change with either all Task actions in series or parallel. For custom
             stage hierarchy the change_control_create_with_custom_stages() should be used.
             Args:
@@ -3587,6 +3597,7 @@ class CvpApi(object):
 
     def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
             Args:
                 cc_id (string): The ID for the new change control.
                 notes (string): An optional note.
@@ -3623,6 +3634,8 @@ class CvpApi(object):
 
     def change_control_stop(self, cc_id, notes=""):
         ''' Stop a Change Control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
+
             Args:
                 cc_id (string): The ID for the new change control.
                 notes (string): An optional note.
@@ -3651,6 +3664,47 @@ class CvpApi(object):
                 return response
             elif self.clnt.apiversion < 6.0:
                     self.log.warning('change_control_stop: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
+        else:
+            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
+
+    def change_control_schedule(self, cc_id, schedule_time, notes=""):
+        ''' Schedule a Change Control using Resource APIs.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
+
+            Args:
+                cc_id (string): The ID for the new change control.
+                schedule_time (string): rfc3339 time format, e.g: 2021-12-23T02:07:00.0Z
+                notes (string): An optional note.
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"value":{"key":{"id":"5821c7c1-e276-4387-b60a"},
+                              "schedule":{"value":"2021-12-23T02:07:00Z",
+                                          "notes":"CC schedule via curl"}},
+                     "time":"2021-12-23T02:06:18.739965204Z"}
+        '''
+        payload = {
+                "key": {
+                    "id": cc_id
+                },
+                "schedule": {
+                    "value": schedule_time,
+                    "notes": notes
+                }
+        }
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
+                return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_schedule: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
                     return None
         else:

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2946,6 +2946,10 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(tag_url, data=payload)
 
@@ -3012,6 +3016,10 @@ class CvpApi(object):
                 self.log.debug('v6 ' + tag_url + ' ' + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(tag_url, data=payload)
 
@@ -3053,6 +3061,10 @@ class CvpApi(object):
                 self.log.debug('v6 {} '.format(tag_url) + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(tag_url, data=payload)
 
@@ -3102,6 +3114,10 @@ class CvpApi(object):
                 self.log.debug('v6 {} '.format(tag_url) + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(tag_url, data=payload)
 
@@ -3121,6 +3137,10 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('get_all_workspaces: Workspace Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(tag_url, data=payload)
 
@@ -3139,6 +3159,10 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.get(tag_url)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('get_workspace: Workspace Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.get(tag_url)
 
@@ -3191,6 +3215,10 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('workspace_config: Workspace Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(url, data=payload)
 
@@ -3214,11 +3242,15 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.get(url, timeout=self.request_timeout)
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('workspace_build_status: Workspace Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_change_control(self, cc_id, cc_time=None):
+    def change_control_get_one(self, cc_id, cc_time=None):
         ''' Get the configuration and status of a change control using Resource APIs.
 
             Args:
@@ -3246,11 +3278,15 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.get(url, timeout=self.request_timeout)
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_get_one: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_all_change_controls(self):
+    def change_control_get_all(self):
         ''' Get the configuration and status of all Change Controls using Resource APIs.
 
             Returns:
@@ -3265,11 +3301,15 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(url))
                 response = self.clnt.get(url, timeout=self.request_timeout)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_get_all: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_change_control_approval(self, cc_id, cc_time=None):
+    def change_control_approval_get_one(self, cc_id, cc_time=None):
         ''' Get the state of a specific Change Control's approve config using Resource APIs.
 
             Args:
@@ -3286,7 +3326,7 @@ class CvpApi(object):
         else:
             params = 'key.id={}&time={}'.format(cc_id, cc_time)
         url = '/api/resources/changecontrol/v1/ApproveConfig?' + params
-        cc_status = self.clnt.api.get_change_control(cc_id)
+        cc_status = self.change_control_get_one(cc_id)
         if 'approve' in cc_status['value']:
             # For on-prem check the version as it is only supported from 2021.2.0+
             if not self.clnt.is_cvaas:
@@ -3294,14 +3334,19 @@ class CvpApi(object):
                     self.get_cvp_info()
                 if self.clnt.apiversion >= 6.0:
                     return self.clnt.get(url, timeout=self.request_timeout)
+                elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_approval_get_one: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
             else:
                 return self.clnt.get(url, timeout=self.request_timeout)
         else:
-            msg = "The change has not been approved yet."
-            return msg
+            self.log.warning("change_control_approval_get_one: The change has not been approved yet."
+                             " A change has to be approved at least once for the 'approve' state to be populated.")
+            return None
 
 
-    def get_all_change_control_approvals(self):
+    def change_control_approval_get_all(self):
         ''' Get state information for all Change Control Approvals using Resource APIs.
 
             Returns:
@@ -3317,6 +3362,10 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(url))
                 response = self.clnt.get(url, timeout=self.request_timeout)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_approval_get_all: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.get(url, timeout=self.request_timeout)
 
@@ -3331,7 +3380,7 @@ class CvpApi(object):
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        version = self.clnt.api.get_change_control(cc_id)['value']['change']['time']
+        version = self.change_control_get_one(cc_id)['value']['change']['time']
         payload = {
             "key": {
                 "id": cc_id
@@ -3359,6 +3408,10 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.delete(url, timeout=self.request_timeout)
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_delete: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.delete(url, timeout=self.request_timeout)
 
@@ -3471,6 +3524,10 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_create_with_custom_stages: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(url, data=payload)
 
@@ -3521,6 +3578,10 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_create_for_tasks: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
@@ -3552,6 +3613,10 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_start: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
@@ -3584,5 +3649,9 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
+            elif self.clnt.apiversion < 6.0:
+                    self.log.warning('change_control_stop: Change Control Resource APIs are supported'
+                                     ' from 2021.2.0 or newer.')
+                    return None
         else:
             return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3304,7 +3304,7 @@ class CvpApi(object):
         cc_status = self.change_control_get_one(cc_id)
         if cc_status is None:
             return None
-        if 'approve' not in cc_status['value']:
+        if 'value' in cc_status and 'approve' not in cc_status['value']:
             self.log.warning("The change has not been approved yet."
                              " A change has to be approved at least once for the 'approve' state to be populated.")
             return None
@@ -3343,16 +3343,14 @@ class CvpApi(object):
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        # try:
-        #     version = self.change_control_get_one(cc_id)['value']['change']['time']
-        # except Exception as e:
-        #     version = None
-        #     return None
         cc_status = self.change_control_get_one(cc_id)
         if cc_status is None:
             return None
         if 'value' in cc_status and 'change' in cc_status['value'] and 'time' in cc_status['value']['change']:
             version = cc_status['value']['change']['time']
+        else:
+            self.log.error('The version timestamp was not found in the CC status.')
+            return None
         payload = {
             "key": {
                 "id": cc_id

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3210,7 +3210,7 @@ class CvpApi(object):
 
 
     def get_change_control(self, key_id, cc_time=None):
-        ''' Get the state of a change control using Resource APIs.
+        ''' Get the configuration and status of a change control using Resource APIs.
 
             Args:
                key_id (str): The ID of the change control.
@@ -3218,12 +3218,13 @@ class CvpApi(object):
                     If no time is given, the server will use the time at which it makes the request.
             Returns:
                response (dict): A dict that contains...
-                  Ex: {"value":{"key":{"id":"<CC ID>"}, "change":{"name":"string",
-                  "rootStageId":"string", "stages":{"values":{"<stageId>":{"name":"<stage name>",
-                  "rows":{"values":[{"values":["string"]}]}}, "<stageId>":{"name":"<action type>",
-                  "action":{"name":"task", "timeout":3000, "args":{"values":{"TaskID":"<tasID>"}}}}}},
-                  "notes":"", "time":"<rfc3339 time>",
-                  "user":"string"}}, "time":"<rfc3339 time>"}%
+                  Ex: {"value":{"key":{"id":"rL6Tog6UU"}, "change":{"name":"Change 20211213_210554",
+                       "rootStageId":"kZUWqyIArD", "stages":{"values":{"kZUWqyIArD":{"name":"Change 20211213_210554 Root",
+                       "rows":{"values":[{"values":["vazWhKyVRR"]}]}}, "vazWhKyVRR":{"name":"Update Config",
+                       "action":{"name":"task", "timeout":3000, "args":{"values":{"TaskID":"538"}}}}}},
+                       "notes":"", "time":"2021-12-13T21:05:58.813750128Z", "user":"cvpadmin"},
+                       "approve":{"value":true, "time":"2021-12-13T21:11:26.788753264Z",
+                       "user":"cvpadmin"}}, "time":"2021-12-13T21:11:26.788753264Z"}%
         '''
         if cc_time is None:
             params = 'key.id={}'.format(key_id)
@@ -3240,12 +3241,59 @@ class CvpApi(object):
 
 
     def get_all_change_controls(self):
-        ''' Get state information for all Change Controls using Resource APIs.
+        ''' Get the configuration and status of all Change Controls using Resource APIs.
 
             Returns:
                response (dict): A dict that contains a list of all Change Controls.
         '''
         url = '/api/resources/changecontrol/v1/ChangeControl/all'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 {}'.format(url))
+                response = self.clnt.get(url, timeout=self.request_timeout)
+                return response
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_change_control_config(self, key_id, cc_time=None):
+        ''' Get the configuration of a change control using Resource APIs.
+
+            Args:
+               key_id (str): The ID of the change control.
+               time (str): Time indicates the time for which you are interested in the data.
+                    If no time is given, the server will use the time at which it makes the request.
+            Returns:
+               response (dict): A dict that contains...
+                  Ex: {"value":{"key":{"id":"rL6Tog6UU"}, "change":{"name":"Change 20211213_210554",
+                  "rootStageId":"kZUWqyIArD", "stages":{"values":{"kZUWqyIArD":{"name":"Change 20211213_210554 Root",
+                  "rows":{"values":[{"values":["vazWhKyVRR"]}]}}, "vazWhKyVRR":{"name":"Update Config",
+                  "action":{"name":"task", "timeout":3000, "args":{"values":{"TaskID":"538"}}}}}},
+                  "notes":""}}, "time":"2021-12-13T21:05:58.813750128Z"}%
+        '''
+        if cc_time is None:
+            params = 'key.id={}'.format(key_id)
+        else:
+            params = 'key.id={}&time={}'.format(key_id, cc_time)
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig?' + params
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                return self.clnt.get(url, timeout=self.request_timeout)
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_all_change_controls_config(self):
+        ''' Get the configuration and status of all Change Controls using Resource APIs.
+
+            Returns:
+               response (dict): A dict that contains a list of all Change Controls.
+        '''
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig/all'
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
@@ -3325,3 +3373,83 @@ class CvpApi(object):
             "version": version
         }
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
+
+    def delete_change_control_config(self, key_id):
+        ''' Delete a pending Change Control using Resource APIs.
+
+            Args:
+              key_id (str): The ID of the change control.
+        '''
+        params = 'key.id={}'.format(key_id)
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig?' + params
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                return self.clnt.delete(url, timeout=self.request_timeout)
+        return self.clnt.delete(url, timeout=self.request_timeout)
+
+
+    def change_control_config_create(self, cc_data):
+        ''' Create a Change Control using Resource APIs.
+        '''
+        payload = cc_data
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+                response = self.clnt.post(url, data=payload)
+                return response
+        return self.clnt.post(url, data=payload)
+
+    def change_control_config_start(self, key_id, notes=""):
+        ''' Start a Change Control using Resource APIs.
+        '''
+        payload = {
+                "key": {
+                    "id": key_id
+                },
+                "start": {
+                    "value": True,
+                    "notes": notes
+                }
+        }
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+                response = self.clnt.post(url, data=payload)
+                return response
+        return self.clnt.post(url, data=payload)
+
+
+    def change_control_config_stop(self, key_id, stages):
+        ''' Stop a Change Control using Resource APIs.
+        '''
+        payload = {
+                "key": {
+                    "id": key_id
+                },
+                "start": {
+                    "value": False,
+                    "notes": notes
+                }
+        }
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+                response = self.clnt.post(url, data=payload)
+                return response
+        return self.clnt.post(url, data=payload)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2942,16 +2942,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(tag_url))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(tag_url, data=payload)
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+                                 ' from 2021.2.0 or newer.')
+                return None
+        self.log.debug('v6 {}'.format(tag_url))
+        return self.clnt.post(tag_url, data=payload)
 
     def get_tag_edits(self, workspace_id):
         ''' Show all tags edits in a workspace
@@ -2981,10 +2977,8 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 self.log.debug('v6 ' + tag_url + ' ' + str(payload))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-        else:
-            return self.clnt.post(tag_url, data=payload)
+                return self.clnt.post(tag_url, data=payload)
+        return self.clnt.post(tag_url, data=payload)
 
     def get_tag_assignment_edits(self, workspace_id):
         ''' Show all tags assignment edits in a workspace
@@ -3012,16 +3006,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + tag_url + ' ' + str(payload))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(tag_url, data=payload)
+                return None
+        self.log.debug('v6 ' + tag_url + ' ' + str(payload))
+        return self.clnt.post(tag_url, data=payload)
 
     def tag_config(self, element_type, workspace_id, tag_label, tag_value, remove=False):
         ''' Create/Delete device or interface tags.
@@ -3057,16 +3047,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {} '.format(tag_url) + str(payload))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(tag_url, data=payload)
+                return None
+        self.log.debug('v6 {} '.format(tag_url) + str(payload))
+        return self.clnt.post(tag_url, data=payload)
 
     def tag_assignment_config(self, element_type, workspace_id, tag_label,
                               tag_value, device_id, interface_id, remove=False):
@@ -3110,16 +3096,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {} '.format(tag_url) + str(payload))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('tag_assignment_config: Tag.V2 Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(tag_url, data=payload)
+                return None
+        self.log.debug('v6 {} '.format(tag_url) + str(payload))
+        return self.clnt.post(tag_url, data=payload)
 
     def get_all_workspaces(self):
         ''' Get state information for all workspaces
@@ -3127,22 +3109,18 @@ class CvpApi(object):
             Returns:
                response (dict): A dict that contains a list of key-values for workspaces
         '''
-        tag_url = '/api/resources/workspace/v1/Workspace/all'
+        url = '/api/resources/workspace/v1/Workspace/all'
         payload = {}
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(tag_url))
-                response = self.clnt.post(tag_url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
+            if self.clnt.apiversion < 6.0:
                     self.log.warning('get_all_workspaces: Workspace Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
                     return None
-        else:
-            return self.clnt.post(tag_url, data=payload)
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.post(url, data=payload)
 
     def get_workspace(self, workspace_id):
         ''' Get state information for all workspaces
@@ -3150,21 +3128,17 @@ class CvpApi(object):
             Returns:
                response (dict): A dict that contains a list of key-values for workspaces
         '''
-        tag_url = '/api/resources/workspace/v1/Workspace?key.workspaceId={}'.format(workspace_id)
+        url = '/api/resources/workspace/v1/Workspace?key.workspaceId={}'.format(workspace_id)
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(tag_url))
-                response = self.clnt.get(tag_url)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('get_workspace: Workspace Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('get_workspace: Workspace Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.get(tag_url)
+                return None
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.get(url)
 
     def workspace_config(self, workspace_id, display_name,
                          description='', request='REQUEST_UNSPECIFIED',
@@ -3211,16 +3185,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('workspace_config: Workspace Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('workspace_config: Workspace Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload)
+                return None
+        self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload)
 
     def workspace_build_status(self, workspace_id, build_id):
         ''' Verify the state of the workspace build process.
@@ -3240,14 +3210,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                return self.clnt.get(url, timeout=self.request_timeout)
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('workspace_build_status: Workspace Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('workspace_build_status: Workspace Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.get(url, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 {}'.format(url+params))
+        return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def change_control_get_one(self, cc_id, cc_time=None):
@@ -3258,6 +3226,7 @@ class CvpApi(object):
                cc_id (str): The ID of the change control.
                cc_time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
+                    The time format is RFC 3339, e.g.: 2021-12-24T11:30:00.00Z.
             Returns:
                response (dict): A dict that contains...
                   Ex: {"value":{"key":{"id":"rL6Tog6UU"}, "change":{"name":"Change 20211213_210554",
@@ -3277,14 +3246,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                return self.clnt.get(url, timeout=self.request_timeout)
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_get_one: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_get_one: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.get(url, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def change_control_get_all(self):
@@ -3299,16 +3266,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(url))
-                response = self.clnt.get(url, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_get_all: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_get_all: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.get(url, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def change_control_approval_get_one(self, cc_id, cc_time=None):
@@ -3319,6 +3282,7 @@ class CvpApi(object):
                cc_id (str): The ID of the change control.
                cc_time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
+                    The time format is RFC 3339, e.g.: 2021-12-24T11:30:00.00Z.
             Returns:
                response (dict): A dict that contains...
                     Ex: {'value': {'key': {'id': '<CC ID>'}, 'approve': {'value': True},
@@ -3329,24 +3293,25 @@ class CvpApi(object):
         else:
             params = 'key.id={}&time={}'.format(cc_id, cc_time)
         url = '/api/resources/changecontrol/v1/ApproveConfig?' + params
-        cc_status = self.change_control_get_one(cc_id)
-        if 'approve' in cc_status['value']:
-            # For on-prem check the version as it is only supported from 2021.2.0+
-            if not self.clnt.is_cvaas:
-                if self.clnt.apiversion is None:
-                    self.get_cvp_info()
-                if self.clnt.apiversion >= 6.0:
-                    return self.clnt.get(url, timeout=self.request_timeout)
-                elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_approval_get_one: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
-                    return None
-            else:
-                return self.clnt.get(url, timeout=self.request_timeout)
-        else:
-            self.log.warning("change_control_approval_get_one: The change has not been approved yet."
-                             " A change has to be approved at least once for the 'approve' state to be populated.")
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_approval_get_one: Change Control Resource APIs are supported'
+                                    ' from 2021.2.0 or newer.')
+                return None
+        try:
+            cc_status = self.change_control_get_one(cc_id)
+        except Exception as e:
+            self.log.warning('change_control_get_one: The change control ID does not exist.')
             return None
+        if 'approve' not in cc_status['value']:
+            self.log.warning("change_control_approval_get_one: The change has not been approved yet."
+                                " A change has to be approved at least once for the 'approve' state to be populated.")
+            return None
+        return self.clnt.get(url, timeout=self.request_timeout)
+
 
 
     def change_control_approval_get_all(self):
@@ -3362,16 +3327,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(url))
-                response = self.clnt.get(url, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_approval_get_all: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_approval_get_all: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.get(url, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.get(url, timeout=self.request_timeout)
 
     def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
@@ -3385,7 +3346,11 @@ class CvpApi(object):
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        version = self.change_control_get_one(cc_id)['value']['change']['time']
+        try:
+            version = self.change_control_get_one(cc_id)['value']['change']['time']
+        except Exception as e:
+            version = None
+            return None
         payload = {
             "key": {
                 "id": cc_id
@@ -3412,14 +3377,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                return self.clnt.delete(url, timeout=self.request_timeout)
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_delete: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_delete: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.delete(url, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 {}'.format(url))
+        return self.clnt.delete(url, timeout=self.request_timeout)
 
 
     def change_control_create_with_custom_stages(self, custom_cc=None):
@@ -3584,16 +3547,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_create_for_tasks: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_create_for_tasks: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
     def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
@@ -3620,16 +3579,12 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_start: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_start: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
 
     def change_control_stop(self, cc_id, notes=""):
@@ -3658,54 +3613,46 @@ class CvpApi(object):
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_stop: Change Control Resource APIs are supported'
+            if self.clnt.apiversion < 6.0:
+                self.log.warning('change_control_stop: Change Control Resource APIs are supported'
                                      ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+                return None
+        self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
+# Commenting this out until it's fully supported
+    # def change_control_schedule(self, cc_id, schedule_time, notes=""):
+    #     ''' Schedule a Change Control using Resource APIs.
+    #         Supported versions: CVP 2021.3.0 or newer and CVaaS.
 
-    def change_control_schedule(self, cc_id, schedule_time, notes=""):
-        ''' Schedule a Change Control using Resource APIs.
-            Supported versions: CVP 2021.2.0 or newer and CVaaS.
-
-            Args:
-                cc_id (string): The ID for the new change control.
-                schedule_time (string): rfc3339 time format, e.g: 2021-12-23T02:07:00.0Z
-                notes (string): An optional note.
-            Returns:
-                response (dict): A dict that contains...
-                Ex: {"value":{"key":{"id":"5821c7c1-e276-4387-b60a"},
-                              "schedule":{"value":"2021-12-23T02:07:00Z",
-                                          "notes":"CC schedule via curl"}},
-                     "time":"2021-12-23T02:06:18.739965204Z"}
-        '''
-        payload = {
-                "key": {
-                    "id": cc_id
-                },
-                "schedule": {
-                    "value": schedule_time,
-                    "notes": notes
-                }
-        }
-        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
-        # For on-prem check the version as it is only supported from 2021.2.0+
-        if not self.clnt.is_cvaas:
-            if self.clnt.apiversion is None:
-                self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
-                return response
-            elif self.clnt.apiversion < 6.0:
-                    self.log.warning('change_control_schedule: Change Control Resource APIs are supported'
-                                     ' from 2021.2.0 or newer.')
-                    return None
-        else:
-            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+    #         Args:
+    #             cc_id (string): The ID for the new change control.
+    #             schedule_time (string): rfc3339 time format, e.g: 2021-12-23T02:07:00.0Z
+    #             notes (string): An optional note.
+    #         Returns:
+    #             response (dict): A dict that contains...
+    #             Ex: {"value":{"key":{"id":"5821c7c1-e276-4387-b60a"},
+    #                           "schedule":{"value":"2021-12-23T02:07:00Z",
+    #                                       "notes":"CC schedule via curl"}},
+    #                  "time":"2021-12-23T02:06:18.739965204Z"}
+    #     '''
+    #     payload = {
+    #             "key": {
+    #                 "id": cc_id
+    #             },
+    #             "schedule": {
+    #                 "value": schedule_time,
+    #                 "notes": notes
+    #             }
+    #     }
+    #     url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+    #     # For on-prem check the version as it is only supported from 2021.2.0+
+    #     if not self.clnt.is_cvaas:
+    #         if self.clnt.apiversion is None:
+    #             self.get_cvp_info()
+    #         if self.clnt.apiversion < 7.0:
+    #             self.log.warning('change_control_schedule: Change Control Resource APIs are supported'
+    #                                  ' from 2021.2.0 or newer.')
+    #             return None
+    #     self.log.debug('v7 ' + str(url) + ' ' + str(payload))
+    #     return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2921,7 +2921,6 @@ class CvpApi(object):
             '/api/v3/services/admin.Enrollment/AddEnrollmentToken',
             data=data, timeout=self.request_timeout)
 
-
     def get_all_tags(self, element_type='ELEMENT_TYPE_UNSPECIFIED', workspace_id=''):
         ''' Get all device and/or interface tags from the mainline workspace or all other workspaces
             Args:
@@ -2948,7 +2947,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {}'.format(tag_url))
         return self.clnt.post(tag_url, data=payload)
-
 
     def get_tag_edits(self, workspace_id):
         ''' Show all tags edits in a workspace
@@ -2982,7 +2980,6 @@ class CvpApi(object):
         self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
 
-
     def get_tag_assignment_edits(self, workspace_id):
         ''' Show all tags assignment edits in a workspace
 
@@ -3014,7 +3011,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
-
 
     def tag_config(self, element_type, workspace_id, tag_label, tag_value, remove=False):
         ''' Create/Delete device or interface tags.
@@ -3055,7 +3051,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {} '.format(tag_url) + str(payload))
         return self.clnt.post(tag_url, data=payload)
-
 
     def tag_assignment_config(self, element_type, workspace_id, tag_label,
                               tag_value, device_id, interface_id, remove=False):
@@ -3214,7 +3209,6 @@ class CvpApi(object):
         self.log.debug('v6 {}'.format(url+params))
         return self.clnt.get(url, timeout=self.request_timeout)
 
-
     def change_control_get_one(self, cc_id, cc_time=None):
         ''' Get the configuration and status of a change control using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3255,7 +3249,6 @@ class CvpApi(object):
             raise error
         return response
 
-
     def change_control_get_all(self):
         ''' Get the configuration and status of all Change Controls using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3273,7 +3266,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.get(url, timeout=self.request_timeout)
-
 
     def change_control_approval_get_one(self, cc_id, cc_time=None):
         ''' Get the state of a specific Change Control's approve config using Resource APIs.
@@ -3310,7 +3302,6 @@ class CvpApi(object):
             return None
         return self.clnt.get(url, timeout=self.request_timeout)
 
-
     def change_control_approval_get_all(self):
         ''' Get state information for all Change Control Approvals using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3329,7 +3320,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.get(url, timeout=self.request_timeout)
-
 
     def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
@@ -3363,7 +3353,6 @@ class CvpApi(object):
         }
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
-
     def change_control_delete(self, cc_id):
         ''' Delete a pending Change Control using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3382,7 +3371,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {}'.format(url))
         return self.clnt.delete(url, timeout=self.request_timeout)
-
 
     def change_control_create_with_custom_stages(self, custom_cc=None):
         ''' Create a Change Control with custom stage hierarchy using Resource APIs.
@@ -3496,7 +3484,6 @@ class CvpApi(object):
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload)
 
-
     def change_control_create_for_tasks(self, cc_id, name, tasks, series=True):
         ''' Create a simple Change Control for tasks using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3548,7 +3535,6 @@ class CvpApi(object):
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
-
     def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
@@ -3579,7 +3565,6 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 ' + str(url) + ' ' + str(payload))
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
-
 
     def change_control_stop(self, cc_id, notes=""):
         ''' Stop a Change Control using Resource APIs.

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3209,11 +3209,11 @@ class CvpApi(object):
         return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_change_control(self, key_id, cc_time=None):
+    def get_change_control(self, cc_id, cc_time=None):
         ''' Get the configuration and status of a change control using Resource APIs.
 
             Args:
-               key_id (str): The ID of the change control.
+               cc_id (str): The ID of the change control.
                time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
             Returns:
@@ -3227,9 +3227,9 @@ class CvpApi(object):
                        "user":"cvpadmin"}}, "time":"2021-12-13T21:11:26.788753264Z"}%
         '''
         if cc_time is None:
-            params = 'key.id={}'.format(key_id)
+            params = 'key.id={}'.format(cc_id)
         else:
-            params = 'key.id={}&time={}'.format(key_id, cc_time)
+            params = 'key.id={}&time={}'.format(cc_id, cc_time)
         url = '/api/resources/changecontrol/v1/ChangeControl?' + params
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
@@ -3258,58 +3258,11 @@ class CvpApi(object):
         return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_change_control_config(self, key_id, cc_time=None):
-        ''' Get the configuration of a change control using Resource APIs.
-
-            Args:
-               key_id (str): The ID of the change control.
-               time (str): Time indicates the time for which you are interested in the data.
-                    If no time is given, the server will use the time at which it makes the request.
-            Returns:
-               response (dict): A dict that contains...
-                  Ex: {"value":{"key":{"id":"rL6Tog6UU"}, "change":{"name":"Change 20211213_210554",
-                  "rootStageId":"kZUWqyIArD", "stages":{"values":{"kZUWqyIArD":{"name":"Change 20211213_210554 Root",
-                  "rows":{"values":[{"values":["vazWhKyVRR"]}]}}, "vazWhKyVRR":{"name":"Update Config",
-                  "action":{"name":"task", "timeout":3000, "args":{"values":{"TaskID":"538"}}}}}},
-                  "notes":""}}, "time":"2021-12-13T21:05:58.813750128Z"}%
-        '''
-        if cc_time is None:
-            params = 'key.id={}'.format(key_id)
-        else:
-            params = 'key.id={}&time={}'.format(key_id, cc_time)
-        url = '/api/resources/changecontrol/v1/ChangeControlConfig?' + params
-        # For on-prem check the version as it is only supported from 2021.2.0+
-        if not self.clnt.is_cvaas:
-            if self.clnt.apiversion is None:
-                self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                return self.clnt.get(url, timeout=self.request_timeout)
-        return self.clnt.get(url, timeout=self.request_timeout)
-
-
-    def get_all_change_controls_config(self):
-        ''' Get the configuration and status of all Change Controls using Resource APIs.
-
-            Returns:
-               response (dict): A dict that contains a list of all Change Controls.
-        '''
-        url = '/api/resources/changecontrol/v1/ChangeControlConfig/all'
-        # For on-prem check the version as it is only supported from 2021.2.0+
-        if not self.clnt.is_cvaas:
-            if self.clnt.apiversion is None:
-                self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
-                self.log.debug('v6 {}'.format(url))
-                response = self.clnt.get(url, timeout=self.request_timeout)
-                return response
-        return self.clnt.get(url, timeout=self.request_timeout)
-
-
-    def get_change_control_approve_config(self, key_id, cc_time=None):
+    def get_change_control_approval(self, cc_id, cc_time=None):
         ''' Get the state of a specific Change Control's approve config using Resource APIs.
 
             Args:
-               key_id (str): The ID of the change control.
+               cc_id (str): The ID of the change control.
                time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
             Returns:
@@ -3318,9 +3271,9 @@ class CvpApi(object):
                          'version': '2021-12-13T21:05:58.813750128Z'}, 'time': '2021-12-13T21:11:26.788753264Z'}
         '''
         if cc_time is None:
-            params = 'key.id={}'.format(key_id)
+            params = 'key.id={}'.format(cc_id)
         else:
-            params = 'key.id={}&time={}'.format(key_id, cc_time)
+            params = 'key.id={}&time={}'.format(cc_id, cc_time)
         url = '/api/resources/changecontrol/v1/ApproveConfig?' + params
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
@@ -3331,7 +3284,7 @@ class CvpApi(object):
         return self.clnt.get(url, timeout=self.request_timeout)
 
 
-    def get_all_change_control_approve_config(self):
+    def get_all_change_control_approvals(self):
         ''' Get state information for all Change Control Approvals using Resource APIs.
 
             Returns:
@@ -3349,11 +3302,11 @@ class CvpApi(object):
                 return response
         return self.clnt.get(url, timeout=self.request_timeout)
 
-    def change_control_approve_config(self, key_id, notes="", approve=True):
+    def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
 
             Args:
-              key_id (str): The ID of the change control.
+              cc_id (str): The ID of the change control.
               version (str): The timestamp of the Change Control. Can be fetched using get_change_control().
               notes (str): An optional approval note.
               approve (bool): Set to True to approve a change and to False to unapprove a change. The default is True.
@@ -3361,10 +3314,10 @@ class CvpApi(object):
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        version = self.clnt.api.get_change_control(key_id)['time']
+        version = self.clnt.api.get_change_control(cc_id)['time']
         payload = {
             "key": {
-                "id": key_id
+                "id": cc_id
             },
             "approve": {
                 "value": approve,
@@ -3375,13 +3328,13 @@ class CvpApi(object):
         return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
 
-    def delete_change_control_config(self, key_id):
+    def change_control_delete(self, cc_id):
         ''' Delete a pending Change Control using Resource APIs.
 
             Args:
-              key_id (str): The ID of the change control.
+              cc_id (str): The ID of the change control.
         '''
-        params = 'key.id={}'.format(key_id)
+        params = 'key.id={}'.format(cc_id)
         url = '/api/resources/changecontrol/v1/ChangeControlConfig?' + params
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
@@ -3392,10 +3345,105 @@ class CvpApi(object):
         return self.clnt.delete(url, timeout=self.request_timeout)
 
 
-    def change_control_config_create(self, cc_data):
-        ''' Create a Change Control using Resource APIs.
+    def change_control_create_with_custom_stages(self, custom_cc=None):
+        ''' Create a Change Control with custom stage hierarchy using Resource APIs.
+            Args:
+                custom_cc (dict): A dictionary with the entire stage hierarchy.
+                Ex1: {'key': {'id': '409b94d1-c0cb-4d74-8f88-89f66f13f109'},
+                     'change': {'name': 'Change_20211217_034338',
+                     'notes': 'cvprac CC',
+                     'rootStageId': 'root',
+                     'stages': {'values': {'root': {'name': 'root',
+                                                'rows': {'values': [{'values': ['1-2']},
+                                                                    {'values': ['3']}]}},
+                                        '1-2': {'name': 'stages 1-2',
+                                                'rows': {'values': [{'values': ['1ab']},
+                                                                    {'values': ['2']}]}},
+                                        '1a': {'action': {'args': {'values': {'TaskID': '1242'}},
+                                                            'name': 'task',
+                                                            'timeout': 3000},
+                                                'name': 'stage 1a'},
+                                        '1ab': {'name': 'stage 1ab',
+                                                'rows': {'values': [{'values': ['1a',
+                                                                                '1b']}]}},
+                                        '1b': {'action': {'args': {'values': {'TaskID': '1243'}},
+                                                            'timeout': 3000},
+                                                'name': 'stage 1b'},
+                                        '2': {'action': {'args': {'values': {'TaskID': '1240'}},
+                                                        'name': 'task',
+                                                        'timeout': 3000},
+                                                'name': 'stage 2'},
+                                        '3': {'action': {'args': {'values': {'TaskID': '1241'}},
+                                                        'name': 'task',
+                                                        'timeout': 3000},
+                                                'name': 'stage 3'},
+                                        }}}}
+                The above would result in the following hierarchy:
+                    root (series)
+                    |- stages 1-2 (series)
+                    |  |- stage 1ab (parallel)
+                    |  |    |- stage 1a
+                    |  |    |- stage 1b
+                    |  |- stage 2
+                    |- stage 3
+
+                Ex2 (MLAG ISSU):
+                    {'key': {'id': 'PXs9cKimC'},
+                     'change': {'name': 'Change 20211217_040530',
+                     'notes': '',
+                     'rootStageId': 'root',
+                     'stages': {'values': { 'root': {'name': 'Change 20211217_040530 Root',
+                                                           'rows': {'values': [{'values': ['left-leafs']}]}},
+                                            'upgrade1': {'action': {'args': {'values': {'TaskID': '1242'}},
+                                                                      'name': 'task',
+                                                                      'timeout': 3000},
+                                                           'name': 'Image Upgrade'},
+                                            'pre-mlag-check-l2': {'action': {'args': {'values': {'DeviceID': 'SN2'}},
+                                                                     'name': 'mlaghealthcheck'},
+                                                          'name': 'Check MLAG Health'},
+                                            'left-leafs': {'name': 'left-leafs',
+                                                          'rows': {'values': [{'values': ['leaf1']},
+                                                                              {'values': ['leaf2']}]}},
+                                            'upgrade2': {'action': {'args': {'values': {'TaskID': '1243'}},
+                                                                      'name': 'task',
+                                                                      'timeout': 3000},
+                                                           'name': 'Image Upgrade'},
+                                            'pre-mlag-check-l1': {'action': {'args': {'values': {'DeviceID': 'SN1'}},
+                                                                     'name': 'mlaghealthcheck'},
+                                                          'name': 'Check MLAG Health'},
+                                            'post-mlag-check-l2': {'action': {'args': {'values': {'DeviceID': 'SN1'}},
+                                                                      'name': 'mlaghealthcheck'},
+                                                           'name': 'Check MLAG Health'},
+                                            'leaf1': {'name': 'leaf1',
+                                                          'rows': {'values': [{'values': ['pre-mlag-check-l1']},
+                                                                              {'values': ['upgrade1']},
+                                                                              {'values': ['post-mlag-check-l1']}]}},
+                                            'post-mlag-check-l1': {'action': {'args': {'values': {'DeviceID': 'SN2'}},
+                                                                      'name': 'mlaghealthcheck'},
+                                                           'name': 'Check MLAG Health'},
+                                            'leaf2': {'name': 'leaf2',
+                                                          'rows': {'values': [{'values': ['pre-mlag-check-l2']},
+                                                                              {'values': ['upgrade2']},
+                                                                              {'values': ['post-mlag-check-l2']}]}}}}}
+                    }
+                    The above would result in the following hierarchy:
+                    root (series)
+                    |- left-leafs (series)
+                       |- leaf1 (series)
+                       |    |- pre-mlag-check-l1
+                       |    |- upgrade1
+                       |    |- post-mlag-check-l1
+                       |- leaf2 (series)
+                            |- pre-mlag-check-l1
+                            |- upgrade1
+                            |- post-mlag-check-l1
+
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {'value': {'key': {'id':cc_id,
+                      'time': '...'}
         '''
-        payload = cc_data
+        payload = custom_cc
         url = '/api/resources/changecontrol/v1/ChangeControlConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         if not self.clnt.is_cvaas:
@@ -3407,12 +3455,68 @@ class CvpApi(object):
                 return response
         return self.clnt.post(url, data=payload)
 
-    def change_control_config_start(self, key_id, notes=""):
+    def change_control_create_for_tasks(self, cc_id, name, tasks, series=True):
+        ''' Create a simple Change Control for tasks using Resource APIs.
+            This function will create a change with either all Task actions in series or parallel. For custom
+            stage hierarchy the change_control_create_with_custom_stages() should be used.
+            Args:
+                cc_id (string): The ID for the new change control.
+                name (string): The name for the new change control.
+                tasks (list): A list of Task IDs as strings
+                    Ex: ['10', '11', '12']
+                series (bool): A flag for running tasks in series or
+                    in parallel. Defaults to True for running in series.
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {'value': {'key': {'id':cc_id,
+                      'time': '...'}
+        '''
+        stages = {'values': {'root': {'name': 'root', 'rows': {'values': []}}}}
+        if series == True:
+            for index, task in enumerate(tasks):
+                stage_id = 'stage%d' % index
+                stages['values']['root']['rows']['values'].append({'values':[stage_id]})
+                stages['values'][stage_id] = {'action': {'args': {'values': {'TaskID': task}},'name':'task','timeout':3000},'name':stage_id}
+        else:
+            stages['values']['root']['rows']['values'].append({'values':[]})
+            for index, task in enumerate(tasks):
+                stage_id = 'stage%d' % index
+                stages['values']['root']['rows']['values'][0]['values'].append(stage_id)
+                stages['values'][stage_id] = {'action': {'args': {'values': {'TaskID': task}},'name':'task','timeout':3000},'name':stage_id}
+        payload = {'key': {
+                        'id': cc_id
+                        },
+                        'change': {
+                                'name': name,
+                                'rootStageId': 'root',
+                                'notes': 'randomString',
+                                'stages': stages
+                        }
+        }
+        url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 ' + str(url) + ' ' + str(payload))
+                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
+                return response
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
+    def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
+            Args:
+                cc_id (string): The ID for the new change control.
+                notes (string): An optional note.
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"value":{"key":{"id":cc_id}, "start":{"value":true, "notes":"note"}},
+                     "time":"2021-12-14T21:02:21.830306071Z"}
         '''
         payload = {
                 "key": {
-                    "id": key_id
+                    "id": cc_id
                 },
                 "start": {
                     "value": True,
@@ -3426,17 +3530,24 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload)
+                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
-        return self.clnt.post(url, data=payload)
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
 
-    def change_control_config_stop(self, key_id, stages):
+    def change_control_stop(self, cc_id, notes=""):
         ''' Stop a Change Control using Resource APIs.
+            Args:
+                cc_id (string): The ID for the new change control.
+                notes (string): An optional note.
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"value":{"key":{"id":cc_id}, "start":{"value":false, "notes":"note"}},
+                     "time":"2021-12-14T21:02:21.830306071Z"}
         '''
         payload = {
                 "key": {
-                    "id": key_id
+                    "id": cc_id
                 },
                 "start": {
                     "value": False,
@@ -3450,6 +3561,6 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
-                response = self.clnt.post(url, data=payload)
+                response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
-        return self.clnt.post(url, data=payload)
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2946,7 +2946,8 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def get_tag_edits(self, workspace_id):
         ''' Show all tags edits in a workspace
@@ -2978,7 +2979,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + tag_url + ' ' + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def get_tag_assignment_edits(self, workspace_id):
         ''' Show all tags assignment edits in a workspace
@@ -3010,7 +3012,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + tag_url + ' ' + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def tag_config(self, element_type, workspace_id, tag_label, tag_value, remove=False):
         ''' Create/Delete device or interface tags.
@@ -3050,7 +3053,8 @@ class CvpApi(object):
                 self.log.debug('v6 {} '.format(tag_url) + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def tag_assignment_config(self, element_type, workspace_id, tag_label,
                               tag_value, device_id, interface_id, remove=False):
@@ -3098,7 +3102,8 @@ class CvpApi(object):
                 self.log.debug('v6 {} '.format(tag_url) + str(payload))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def get_all_workspaces(self):
         ''' Get state information for all workspaces
@@ -3116,7 +3121,8 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.post(tag_url, data=payload)
                 return response
-        return self.clnt.post(tag_url, data=payload)
+        else:
+            return self.clnt.post(tag_url, data=payload)
 
     def get_workspace(self, workspace_id):
         ''' Get state information for all workspaces
@@ -3133,7 +3139,8 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(tag_url))
                 response = self.clnt.get(tag_url)
                 return response
-        return self.clnt.get(tag_url)
+        else:
+            return self.clnt.get(tag_url)
 
     def workspace_config(self, workspace_id, display_name,
                          description='', request='REQUEST_UNSPECIFIED',
@@ -3184,7 +3191,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload)
                 return response
-        return self.clnt.post(url, data=payload)
+        else:
+            return self.clnt.post(url, data=payload)
 
     def workspace_build_status(self, workspace_id, build_id):
         ''' Verify the state of the workspace build process.
@@ -3206,7 +3214,8 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.get(url, timeout=self.request_timeout)
-        return self.clnt.get(url, timeout=self.request_timeout)
+        else:
+            return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def get_change_control(self, cc_id, cc_time=None):
@@ -3214,7 +3223,7 @@ class CvpApi(object):
 
             Args:
                cc_id (str): The ID of the change control.
-               time (str): Time indicates the time for which you are interested in the data.
+               cc_time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
             Returns:
                response (dict): A dict that contains...
@@ -3237,7 +3246,8 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.get(url, timeout=self.request_timeout)
-        return self.clnt.get(url, timeout=self.request_timeout)
+        else:
+            return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def get_all_change_controls(self):
@@ -3255,7 +3265,8 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(url))
                 response = self.clnt.get(url, timeout=self.request_timeout)
                 return response
-        return self.clnt.get(url, timeout=self.request_timeout)
+        else:
+            return self.clnt.get(url, timeout=self.request_timeout)
 
 
     def get_change_control_approval(self, cc_id, cc_time=None):
@@ -3263,7 +3274,7 @@ class CvpApi(object):
 
             Args:
                cc_id (str): The ID of the change control.
-               time (str): Time indicates the time for which you are interested in the data.
+               cc_time (str): Time indicates the time for which you are interested in the data.
                     If no time is given, the server will use the time at which it makes the request.
             Returns:
                response (dict): A dict that contains...
@@ -3275,13 +3286,19 @@ class CvpApi(object):
         else:
             params = 'key.id={}&time={}'.format(cc_id, cc_time)
         url = '/api/resources/changecontrol/v1/ApproveConfig?' + params
-        # For on-prem check the version as it is only supported from 2021.2.0+
-        if not self.clnt.is_cvaas:
-            if self.clnt.apiversion is None:
-                self.get_cvp_info()
-            if self.clnt.apiversion >= 6.0:
+        cc_status = self.clnt.api.get_change_control(cc_id)
+        if 'approve' in cc_status['value']:
+            # For on-prem check the version as it is only supported from 2021.2.0+
+            if not self.clnt.is_cvaas:
+                if self.clnt.apiversion is None:
+                    self.get_cvp_info()
+                if self.clnt.apiversion >= 6.0:
+                    return self.clnt.get(url, timeout=self.request_timeout)
+            else:
                 return self.clnt.get(url, timeout=self.request_timeout)
-        return self.clnt.get(url, timeout=self.request_timeout)
+        else:
+            msg = "The change has not been approved yet."
+            return msg
 
 
     def get_all_change_control_approvals(self):
@@ -3300,21 +3317,21 @@ class CvpApi(object):
                 self.log.debug('v6 {}'.format(url))
                 response = self.clnt.get(url, timeout=self.request_timeout)
                 return response
-        return self.clnt.get(url, timeout=self.request_timeout)
+        else:
+            return self.clnt.get(url, timeout=self.request_timeout)
 
     def change_control_approve(self, cc_id, notes="", approve=True):
         ''' Approve/Unapprove a change control using Resource APIs.
 
             Args:
               cc_id (str): The ID of the change control.
-              version (str): The timestamp of the Change Control. Can be fetched using get_change_control().
               notes (str): An optional approval note.
               approve (bool): Set to True to approve a change and to False to unapprove a change. The default is True.
         '''
         url = '/api/resources/changecontrol/v1/ApproveConfig'
         # For on-prem check the version as it is only supported from 2021.2.0+
         # Since the get_change_control already checks this, no need to check it again
-        version = self.clnt.api.get_change_control(cc_id)['time']
+        version = self.clnt.api.get_change_control(cc_id)['value']['change']['time']
         payload = {
             "key": {
                 "id": cc_id
@@ -3342,7 +3359,8 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.delete(url, timeout=self.request_timeout)
-        return self.clnt.delete(url, timeout=self.request_timeout)
+        else:
+            return self.clnt.delete(url, timeout=self.request_timeout)
 
 
     def change_control_create_with_custom_stages(self, custom_cc=None):
@@ -3453,7 +3471,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload)
                 return response
-        return self.clnt.post(url, data=payload)
+        else:
+            return self.clnt.post(url, data=payload)
 
     def change_control_create_for_tasks(self, cc_id, name, tasks, series=True):
         ''' Create a simple Change Control for tasks using Resource APIs.
@@ -3502,7 +3521,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
-        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+        else:
+            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
     def change_control_start(self, cc_id, notes=""):
         ''' Start a Change Control using Resource APIs.
@@ -3532,7 +3552,8 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
-        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+        else:
+            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
 
 
     def change_control_stop(self, cc_id, notes=""):
@@ -3563,4 +3584,5 @@ class CvpApi(object):
                 self.log.debug('v6 ' + str(url) + ' ' + str(payload))
                 response = self.clnt.post(url, data=payload, timeout=self.request_timeout)
                 return response
-        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+        else:
+            return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2921,6 +2921,7 @@ class CvpApi(object):
             '/api/v3/services/admin.Enrollment/AddEnrollmentToken',
             data=data, timeout=self.request_timeout)
 
+
     def get_all_tags(self, element_type='ELEMENT_TYPE_UNSPECIFIED', workspace_id=''):
         ''' Get all device and/or interface tags from the mainline workspace or all other workspaces
             Args:
@@ -2947,6 +2948,7 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {}'.format(tag_url))
         return self.clnt.post(tag_url, data=payload)
+
 
     def get_tag_edits(self, workspace_id):
         ''' Show all tags edits in a workspace
@@ -2980,6 +2982,7 @@ class CvpApi(object):
         self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
 
+
     def get_tag_assignment_edits(self, workspace_id):
         ''' Show all tags assignment edits in a workspace
 
@@ -3011,6 +3014,7 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 ' + tag_url + ' ' + str(payload))
         return self.clnt.post(tag_url, data=payload)
+
 
     def tag_config(self, element_type, workspace_id, tag_label, tag_value, remove=False):
         ''' Create/Delete device or interface tags.
@@ -3051,6 +3055,7 @@ class CvpApi(object):
                 return None
         self.log.debug('v6 {} '.format(tag_url) + str(payload))
         return self.clnt.post(tag_url, data=payload)
+
 
     def tag_assignment_config(self, element_type, workspace_id, tag_label,
                               tag_value, device_id, interface_id, remove=False):
@@ -3164,7 +3169,6 @@ class CvpApi(object):
                          'time': 'rfc3339 time'}
         '''
         url = '/api/resources/workspace/v1/WorkspaceConfig'
-
         payload = {
             "key": {
                 "workspaceId": workspace_id
@@ -3247,7 +3251,6 @@ class CvpApi(object):
             response = self.clnt.get(url, timeout=self.request_timeout)
         except Exception as error:
             if 'resource not found' in str(error):
-                self.log.error('Change Control ID does not exist!')
                 return None
             raise error
         return response

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3207,3 +3207,121 @@ class CvpApi(object):
             if self.clnt.apiversion >= 6.0:
                 return self.clnt.get(url, timeout=self.request_timeout)
         return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_change_control(self, key_id, cc_time=None):
+        ''' Get the state of a change control using Resource APIs.
+
+            Args:
+               key_id (str): The ID of the change control.
+               time (str): Time indicates the time for which you are interested in the data.
+                    If no time is given, the server will use the time at which it makes the request.
+            Returns:
+               response (dict): A dict that contains...
+                  Ex: {"value":{"key":{"id":"<CC ID>"}, "change":{"name":"string",
+                  "rootStageId":"string", "stages":{"values":{"<stageId>":{"name":"<stage name>",
+                  "rows":{"values":[{"values":["string"]}]}}, "<stageId>":{"name":"<action type>",
+                  "action":{"name":"task", "timeout":3000, "args":{"values":{"TaskID":"<tasID>"}}}}}},
+                  "notes":"", "time":"<rfc3339 time>",
+                  "user":"string"}}, "time":"<rfc3339 time>"}%
+        '''
+        if cc_time is None:
+            params = 'key.id={}'.format(key_id)
+        else:
+            params = 'key.id={}&time={}'.format(key_id, cc_time)
+        url = '/api/resources/changecontrol/v1/ChangeControl?' + params
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                return self.clnt.get(url, timeout=self.request_timeout)
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_all_change_controls(self):
+        ''' Get state information for all Change Controls using Resource APIs.
+
+            Returns:
+               response (dict): A dict that contains a list of all Change Controls.
+        '''
+        url = '/api/resources/changecontrol/v1/ChangeControl/all'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 {}'.format(url))
+                response = self.clnt.get(url, timeout=self.request_timeout)
+                return response
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_change_control_approve_config(self, key_id, cc_time=None):
+        ''' Get the state of a specific Change Control's approve config using Resource APIs.
+
+            Args:
+               key_id (str): The ID of the change control.
+               time (str): Time indicates the time for which you are interested in the data.
+                    If no time is given, the server will use the time at which it makes the request.
+            Returns:
+               response (dict): A dict that contains...
+                    Ex: {'value': {'key': {'id': '<CC ID>'}, 'approve': {'value': True},
+                         'version': '2021-12-13T21:05:58.813750128Z'}, 'time': '2021-12-13T21:11:26.788753264Z'}
+        '''
+        if cc_time is None:
+            params = 'key.id={}'.format(key_id)
+        else:
+            params = 'key.id={}&time={}'.format(key_id, cc_time)
+        url = '/api/resources/changecontrol/v1/ApproveConfig?' + params
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                return self.clnt.get(url, timeout=self.request_timeout)
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+
+    def get_all_change_control_approve_config(self):
+        ''' Get state information for all Change Control Approvals using Resource APIs.
+
+            Returns:
+               response (dict): A dict that contains a list of all Change Control Approval Configs.
+        '''
+        url = '/api/resources/changecontrol/v1/ApproveConfig/all'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion >= 6.0:
+                self.log.debug('v6 {}'.format(url))
+                response = self.clnt.get(url, timeout=self.request_timeout)
+                return response
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+    def change_control_approve_config(self, key_id, notes="", approve=True):
+        ''' Approve/Unapprove a change control using Resource APIs.
+
+            Args:
+              key_id (str): The ID of the change control.
+              version (str): The timestamp of the Change Control. Can be fetched using get_change_control().
+              notes (str): An optional approval note.
+              approve (bool): Set to True to approve a change and to False to unapprove a change. The default is True.
+        '''
+        url = '/api/resources/changecontrol/v1/ApproveConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        # Since the get_change_control already checks this, no need to check it again
+        version = self.clnt.api.get_change_control(key_id)['time']
+        payload = {
+            "key": {
+                "id": key_id
+            },
+            "approve": {
+                "value": approve,
+                "notes": notes
+            },
+            "version": version
+        }
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/docs/labs/lab06-provisioning/change_control_custom_rapi.py
+++ b/docs/labs/lab06-provisioning/change_control_custom_rapi.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the COPYING file.
+#
+# NOTE: The following example is using the new Change Control Resource APIs supported in 2021.2.0 or newer and in CVaaS.
+# For CVaaS service-account token based auth has to be used.
+
+from cvprac.cvp_client import CvpClient
+import ssl
+import uuid
+from datetime import datetime
+ssl._create_default_https_context = ssl._create_unverified_context
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+
+# Create connection to CloudVision
+clnt = CvpClient()
+clnt.connect(['cvp1'],'username', 'password')
+
+
+cc_id = str(uuid.uuid4())
+name = f"Change_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+# Create custom stage hierarchy
+# The below example would result in the following hierarchy:
+# root (series)
+# |- stages 1-2 (series)
+# |  |- stage 1ab (parallel)
+# |  |    |- stage 1a
+# |  |    |- stage 1b
+# |  |- stage 2
+# |- stage 3
+data = {'key': {
+            'id': cc_id
+            },
+        'change': {
+            'name': cc_id,
+            'notes': 'cvprac CC',
+            'rootStageId': 'root',
+            'stages': {'values': {'root': {'name': 'root',
+                                           'rows': {'values': [{'values': ['1-2']},
+                                                               {'values': ['3']}]
+                                            }
+                                        },
+                                  '1-2': {'name': 'stages 1-2',
+                                          'rows': {'values': [{'values': ['1ab']},
+                                                              {'values': ['2']}]}},
+                                  '1ab': {'name': 'stage 1ab',
+                                          'rows': {'values': [{'values': ['1a','1b']}]
+                                            }
+                                        },
+                                  '1a': {'action': {'args': {'values': {'TaskID': '1242'}},
+                                                    'name': 'task',
+                                                    'timeout': 3000},
+                                         'name': 'stage 1a'},
+                                  '1b': {'action': {'args': {'values': {'TaskID': '1243'}},
+                                                    'name': 'task',
+                                                    'timeout': 3000},
+                                         'name': 'stage 1b'},
+                                  '2': {'action': {'args': {'values': {'TaskID': '1240'}},
+                                                   'name': 'task',
+                                                   'timeout': 3000},
+                                        'name': 'stage 2'},
+                                  '3': {'action': {'args': {'values': {'TaskID': '1241'}},
+                                                   'name': 'task',
+                                                   'timeout': 3000},
+                                        'name': 'stage 3'},
+                }
+            }
+        }
+ }
+# Create change control from custom stage hierarchy data
+clnt.api.change_control_create_with_custom_stages(data)
+
+# Approve the change control
+approval_note = "Approve CC via cvprac" # notes are optional
+clnt.api.change_control_approve(cc_id, notes=approval_note)
+
+# Start the change control
+start_note = "Starting CC via cvprac" # notes are optional
+clnt.api.change_control_start(cc_id, notes=start_note)

--- a/docs/labs/lab06-provisioning/change_control_workflow_rapi.py
+++ b/docs/labs/lab06-provisioning/change_control_workflow_rapi.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the COPYING file.
+#
+# NOTE: The following example is using the new Change Control Resource APIs supported in 2021.2.0 or newer and in CVaaS.
+# For CVaaS service-account token based auth has to be used.
+
+from cvprac.cvp_client import CvpClient
+import ssl
+import uuid
+from datetime import datetime
+ssl._create_default_https_context = ssl._create_unverified_context
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+
+# Create connection to CloudVision
+clnt = CvpClient()
+clnt.connect(['cvp1'],'username', 'password')
+
+# Generate change control id and change control name
+cc_id = str(uuid.uuid4())
+name = f"Change_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+# Select the tasks and create a CC where all tasks will be run in parallel
+tasks = ["1249","1250","1251","1252"]
+clnt.api.change_control_create_for_tasks(cc_id, name, tasks, series=False)
+
+# Approve the change control
+approve_note = "Approving CC via cvprac"
+clnt.api.change_control_approve(cc_id, notes=approve_note)
+
+# # Schedule the change control
+# # Executing scheduled CCs might only work post 2021.3.0+
+# schedule_note = "Scheduling CC via cvprac"
+# schedule_time = "2021-12-23T03:17:00Z"
+# clnt.api.change_control_schedule(cc_id,schedule_time,notes=schedule_note)
+
+# Start the change control
+start_note = "Start the CC via cvprac"
+clnt.api.change_control_start(cc_id, notes=start_note)


### PR DESCRIPTION
This PR is to add wrappers for the new [Change Control Resource APIs ](https://aristanetworks.github.io/cloudvision-apis/models/changecontrol.v1/)introduced in 2021.2.0

The following new functions were added:
- change_control_get_one
- change_controls_get_all
- change_control_approval_get_one
- change_control_approval_get_all
- change_control_approve
- change_control_delete
- change_control_create_with_custom_stages
- change_control_create_for_tasks
- change_control_start
- change_control_stop
- change_control_schedule

All functions have detailed docstrings
CC creation is possible either via `change_control_create_for_tasks` which can generate a CC based on a list of task and run them in series or parallel, or more complex CCs can be created with `change_control_create_with_custom_stages` where the dictionary that holds the stage hierarchy has to be provided by the user (two examples provided in the docstring)

Here are two examples (we'll add these to the lab section later):
Ex1) Create simple CC

```python
from cvprac.cvp_client import CvpClient
import ssl
import uuid
from datetime import datetime
ssl._create_default_https_context = ssl._create_unverified_context
import requests.packages.urllib3
requests.packages.urllib3.disable_warnings()
clnt = CvpClient()
clnt.connect(['cvp'],'username', 'password')

cc_id = str(uuid.uuid4())
name = f"Change_{datetime.now().strftime('%Y%m%d_%H%M%S')}"

# Create CC with all tasks to be executed in parallel
tasks = ["1240","1241","1242","1243"]
print(clnt.api.change_control_create_for_tasks(cc_id, name, tasks, series=True)
```

Ex2) Create complex CC with custom hierarchy

```python
from cvprac.cvp_client import CvpClient
import ssl
import uuid
from datetime import datetime
ssl._create_default_https_context = ssl._create_unverified_context
import requests.packages.urllib3
requests.packages.urllib3.disable_warnings()
clnt = CvpClient()
clnt.connect(['cvp'],'username', 'password')
cc_id = str(uuid.uuid4())
name = f"Change_{datetime.now().strftime('%Y%m%d_%H%M%S')}"

data = {'key': {
            'id': cc_id
            },
        'change': {
            'name': cc_id,
            'notes': 'cvprac CC',
            'rootStageId': 'root',
            'stages': {'values': {'root': {'name': 'root',
                                           'rows': {'values': [{'values': ['1-2']},
                                                               {'values': ['3']}]
                                            }
                                        },
                                  '1-2': {'name': 'stages 1-2',
                                          'rows': {'values': [{'values': ['1ab']},
                                                              {'values': ['2']}]}},
                                  '1ab': {'name': 'stage 1ab',
                                          'rows': {'values': [{'values': ['1a','1b']}]
                                            }
                                        },
                                  '1a': {'action': {'args': {'values': {'TaskID': '1242'}},
                                                    'name': 'task',
                                                    'timeout': 0},
                                         'name': 'stage 1a'},
                                  '1b': {'action': {'args': {'values': {'TaskID': '1243'}},
                                                    'name': 'task',
                                                    'timeout': 0},
                                         'name': 'stage 1b'},
                                  '2': {'action': {'args': {'values': {'TaskID': '1240'}},
                                                   'name': 'task',
                                                   'timeout': 0},
                                        'name': 'stage 2'},
                                  '3': {'action': {'args': {'values': {'TaskID': '1241'}},
                                                   'name': 'task',
                                                   'timeout': 0},
                                        'name': 'stage 3'},
                }
            }
        }
 }

print(clnt.api.change_control_create_with_custom_stages(data))
```

The above would result in the following hierarchy:

 ```
root (series)
 |- stages 1-2 (series)
 |  |- stage 1ab (parallel)
 |  |    |- stage 1a
 |  |    |- stage 1b
 |  |- stage 2
 |- stage 3
```

Added two examples in lab06