### PR TITLE
Adding the decommission APIs available from 2021.3.0

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3712,8 +3712,9 @@ class CvpApi(object):
                     Recommended to generate uuid with str(uuid.uuid4()).
             Returns:
                 response (dict): A dict that contains...
-                Ex: {"value":{"key":{"id":cc_id}, "start":{"value":false, "notes":"note"}},
-                     "time":"2021-12-14T21:02:21.830306071Z"}
+                Ex: {'value': {'key': {'requestId': '4a4ba5a2-9886-4cd5-84d6-bdaf85a9f091'},
+                     'deviceId': 'BAD032986065E8DC14CBB6472EC314A6'},
+                     'time': '2022-02-12T02:58:30.765459650Z'}
         '''
         payload = {
             "key": {

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3668,7 +3668,7 @@ class CvpApi(object):
 # Commenting this out until it's fully supported
     # def change_control_schedule(self, cc_id, schedule_time, notes=""):
     #     ''' Schedule a Change Control using Resource APIs.
-    #         Supported versions: CVP 2021.3.0 or newer and CVaaS.
+    #         Supported versions: CVP 2022.1.0 or newer and CVaaS.
 
     #         Args:
     #             cc_id (string): The ID for the new change control.
@@ -3691,13 +3691,107 @@ class CvpApi(object):
     #             }
     #     }
     #     cc_url = '/api/resources/changecontrol/v1/ChangeControlConfig'
-    #     # For on-prem check the version as it is only supported from 2021.2.0+
+    #     # For on-prem check the version as it is only supported from 2022.1.0+
     #     if not self.clnt.is_cvaas:
     #         if self.clnt.apiversion is None:
     #             self.get_cvp_info()
-    #         if self.clnt.apiversion < 7.0:
+    #         if self.clnt.apiversion < 8.0:
     #             self.log.warning(
-    #                  'Change Control Resource APIs are supported from 2021.2.0 or newer.')
+    #                  'Change Control Resource APIs are supported from 2022.1.0 or newer.')
     #             return None
-    #     self.log.debug('v7 ' + str(cc_url) + ' ' + str(payload))
+    #     self.log.debug('v8 ' + str(cc_url) + ' ' + str(payload))
     #     return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
+
+    def device_decommissioning(self, device_id, request_id):
+        ''' Decommission a device using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+
+            Args:
+                device_id (string): Serial Number of the device.
+                request_id (string): Key identifies the request to decommission the device.
+                    Recommended to generate uuid with str(uuid.uuid4()).
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"value":{"key":{"id":cc_id}, "start":{"value":false, "notes":"note"}},
+                     "time":"2021-12-14T21:02:21.830306071Z"}
+        '''
+        payload = {
+            "key": {
+                "request_id": request_id
+            },
+            "device_id": device_id
+        }
+        url = '/api/resources/inventory/v1/DeviceDecommissioningConfig'
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
+    def device_decommissioning_status_get_one(self, request_id):
+        ''' Get the decommission status of a device using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+
+            Args:
+                request_id (string): key identifies the request to decommission the device
+            Returns:
+                response (dict): A dict that contains...
+                Ex:{"result":{"value":{"key":{"requestId":"123456789"},
+                  "status":"DECOMMISSIONING_STATUS_IN_PROGRESS",
+                  "statusMessage":"Disabled TerminAttr, waiting for device to be marked inactive"},
+                  "time":"2022-02-04T19:41:46.376310308Z","type":"INITIAL"}}
+        '''
+        params = 'key.requestId={}'.format(request_id)
+        url = '/api/resources/inventory/v1/DeviceDecommissioning?' + params
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url))
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+    def device_decommissioning_status_get_all(self, status="DECOMMISSIONING_STATUS_UNSPECIFIED"):
+        ''' Get the decommissioning status of all devices using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+
+            Args:
+                status (enum): By default it will get the decommissioning status for all devices.
+                    Possible values:
+                        "DECOMMISSIONING_STATUS_UNSPECIFIED" or 0,
+                        "DECOMMISSIONING_STATUS_IN_PROGRESS" or 1,
+                        "DECOMMISSIONING_STATUS_FAILURE" or 2,
+                        "DECOMMISSIONING_STATUS_SUCCESS" or 3
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"result":{"value":{"key":{"requestId":"123456789"},
+                "status":"DECOMMISSIONING_STATUS_IN_PROGRESS",
+                "statusMessage":"Disabled TerminAttr, waiting for device to be marked inactive"},
+                "time":"2022-02-04T19:41:46.376310308Z","type":"INITIAL"}}
+        '''
+        payload = {
+            "partialEqFilter": [
+                {
+                    "status": status,
+                }
+            ]
+        }
+        url = '/api/resources/inventory/v1/DeviceDecommissioning/all'
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -201,7 +201,9 @@ class CvpClient(object):
             For CVP versions 2019.0.0 through 2020.1.0, use api version 3.0
             For CVP versions 2020.1.1 through 2020.2.3, use api version 4.0
             For CVP versions 2020.2.4 through 2021.1.x, use api version 5.0
-            For CVP versions 2021.2.0 and beyond, use api version 6.0
+            For CVP versions 2021.2.x, use api version 6.0
+            For CVP versions 2021.3.x, use api version 7.0
+            For CVP versions 2022.1.0 and beyond, use api version 8.0
 
             Args:
                 version (str): The CVP version in use.
@@ -209,7 +211,9 @@ class CvpClient(object):
         self.version = version
         self.log.info('Version %s', version)
         # Set apiversion to latest available API version for CVaaS
-        # Set apiversion to 6.0 for 2021.2.0 and beyond
+        # Set apiversion to 8.0 for 2022.1.x
+        # Set apiversion to 7.0 for 2021.3.x
+        # Set apiversion to 6.0 for 2021.2.x
         # Set apiversion to 5.0 for 2020.2.4 through 2021.1.x
         # Set apiversion to 4.0 for 2020.1.1 through 2020.2.3
         # Set apiversion to 3.0 for 2019.0.0 through 2020.1.0
@@ -227,7 +231,13 @@ class CvpClient(object):
                               ' Appending 0. Updated Version String - %s',
                               ".".join(version_components))
             full_version = ".".join(version_components)
-            if parse_version(full_version) >= parse_version('2021.2.0'):
+            if parse_version(full_version) >= parse_version('2022.1.0'):
+                self.log.info('Setting API version to v8')
+                self.apiversion = 8.0
+            elif parse_version(full_version) >= parse_version('2021.3.0'):
+                self.log.info('Setting API version to v7')
+                self.apiversion = 7.0
+            elif parse_version(full_version) >= parse_version('2021.2.0'):
                 self.log.info('Setting API version to v6')
                 self.apiversion = 6.0
             elif parse_version(full_version) >= parse_version('2020.2.4'):


### PR DESCRIPTION
Adding 3 decommission resource APIs introduced in 2021.3.0

- device_decommissioning
- device_decommissioning_status_get_one
- device_decommissioning_status_get_all

There has been no way previously to automatically decommission devices, this new API sends an eAPI request to EOS to shutdown the TerminAttr daemon, then it removes the device from Network Provisioning and then decommissions it (ie removes it from the Inventory as well). The get_one and get_all calls can be used to track the progress of the decommissioning

few examples:

```
clnt2.api.device_decommissioning(device_id, request_id)
{'value': {'key': {'requestId': '69ae46c9-5dd7-47b8-a9f7-f20f4e63d6c7'}, 'deviceId': '0123F2E4462997EB155B7C50EC148767'}, 'time': '2022-02-12T04:43:20.130244302Z'}

clnt2.api.device_decommissioning_status_get_one(request_id)
{'value': {'key': {'requestId': '69ae46c9-5dd7-47b8-a9f7-f20f4e63d6c7'}, 'status': 'DECOMMISSIONING_STATUS_IN_PROGRESS', 'statusMessage': 'Disabled TerminAttr, waiting for device to be marked inactive'}, 'time': '2022-02-12T04:43:29.867168787Z'}


clnt2.api.device_decommissioning_status_get_all()
{'data': [{'result': {'value': {'key': {'requestId': '388aac03-7baa-4690-9df6-b0667d6b236e'}, 'status': 'DECOMMISSIONING_STATUS_SUCCESS', 'statusMessage': 'Device decommissioned successfully'}, 'time': '2022-02-12T03:07:45.921404253Z', 'type': 'INITIAL'}},{'value': {'key': {'requestId': '2337d655-b1e5-4003-9325-beff8c9e7f4a'}, 'status': 'DECOMMISSIONING_STATUS_FAILURE', 'error': 'Timed out waiting for device BAD032986065E8DC14CBB6472EC314A6 status to be inactive', 'statusMessage': ''}, 'time': '2022-02-12T03:07:45.921396314Z', 'type': 'INITIAL'}}, {'result': {'value': {'key': {'requestId': '69ae46c9-5dd7-47b8-a9f7-f20f4e63d6c7'}, 'status': 'DECOMMISSIONING_STATUS_SUCCESS', 'statusMessage': 'Device decommissioned successfully'}, 'time': '2022-02-12T04:45:48.388350687Z', 'type': 'INITIAL'}}
```

have to check for tests what would be the best as there's an existing [test_api_inventory()](https://github.com/aristanetworks/cvprac/blob/develop/test/system/test_cvp_api.py#L1787) which uses the older delete_device API, which only deletes the device from network provisioning