### PR TITLE
resource apis: readd decomm APIs and uncomment the CC scheduling APIs…

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3709,7 +3709,7 @@ class CvpApi(object):
                 request_id (string): Key identifies the request to decommission the device.
                     Recommended to generate uuid with str(uuid.uuid4()).
             Returns:
-                response (dict): A dict that contains...
+                response (dict): Returns None if the device is not found else returns A dict that contains...
                 Ex: {'value': {'key': {'requestId': '4a4ba5a2-9886-4cd5-84d6-bdaf85a9f091'},
                      'deviceId': 'BAD032986065E8DC14CBB6472EC314A6'},
                      'time': '2022-02-12T02:58:30.765459650Z'}

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3734,7 +3734,7 @@ class CvpApi(object):
             self.log.debug('v7 ' + str(url) + ' ' + str(payload))
             return self.clnt.post(url, data=payload, timeout=self.request_timeout)
         else:
-            self.log.warning('Device with %s serial number does not exist' % device_id)
+            self.log.warning('Device with %s serial number does not exist (or is not registered) to decommission' % device_id)
             return None
 
     def device_decommissioning_status_get_one(self, request_id):

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3665,39 +3665,130 @@ class CvpApi(object):
         self.log.debug('v6 ' + str(cc_url) + ' ' + str(payload))
         return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
 
-# Commenting this out until it's fully supported
-    # def change_control_schedule(self, cc_id, schedule_time, notes=""):
-    #     ''' Schedule a Change Control using Resource APIs.
-    #         Supported versions: CVP 2021.3.0 or newer and CVaaS.
+    def change_control_schedule(self, cc_id, schedule_time, notes=""):
+        ''' Schedule a Change Control using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
 
-    #         Args:
-    #             cc_id (string): The ID for the new change control.
-    #             schedule_time (string): rfc3339 time format, e.g: 2021-12-23T02:07:00.0Z
-    #             notes (string): An optional note.
-    #         Returns:
-    #             response (dict): A dict that contains...
-    #             Ex: {"value":{"key":{"id":"5821c7c1-e276-4387-b60a"},
-    #                           "schedule":{"value":"2021-12-23T02:07:00Z",
-    #                                       "notes":"CC schedule via curl"}},
-    #                  "time":"2021-12-23T02:06:18.739965204Z"}
-    #     '''
-    #     payload = {
-    #             "key": {
-    #                 "id": cc_id
-    #             },
-    #             "schedule": {
-    #                 "value": schedule_time,
-    #                 "notes": notes
-    #             }
-    #     }
-    #     cc_url = '/api/resources/changecontrol/v1/ChangeControlConfig'
-    #     # For on-prem check the version as it is only supported from 2021.2.0+
-    #     if not self.clnt.is_cvaas:
-    #         if self.clnt.apiversion is None:
-    #             self.get_cvp_info()
-    #         if self.clnt.apiversion < 7.0:
-    #             self.log.warning(
-    #                  'Change Control Resource APIs are supported from 2021.2.0 or newer.')
-    #             return None
-    #     self.log.debug('v7 ' + str(cc_url) + ' ' + str(payload))
-    #     return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
+            Args:
+                cc_id (string): The ID for the new change control.
+                schedule_time (string): rfc3339 time format, e.g: 2021-12-23T02:07:00.0Z
+                notes (string): An optional note.
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"value":{"key":{"id":"5821c7c1-e276-4387-b60a"},
+                              "schedule":{"value":"2021-12-23T02:07:00Z",
+                                          "notes":"CC schedule via curl"}},
+                     "time":"2021-12-23T02:06:18.739965204Z"}
+        '''
+        payload = {
+                "key": {
+                    "id": cc_id
+                },
+                "schedule": {
+                    "value": schedule_time,
+                    "notes": notes
+                }
+        }
+        cc_url = '/api/resources/changecontrol/v1/ChangeControlConfig'
+        # For on-prem check the version as it is only supported from 2021.2.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                     'Change Control Resource APIs are supported from 2021.2.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(cc_url) + ' ' + str(payload))
+        return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
+
+    def device_decommissioning(self, device_id, request_id):
+        ''' Decommission a device using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+            Args:
+                device_id (string): Serial Number of the device.
+                request_id (string): Key identifies the request to decommission the device.
+                    Recommended to generate uuid with str(uuid.uuid4()).
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {'value': {'key': {'requestId': '4a4ba5a2-9886-4cd5-84d6-bdaf85a9f091'},
+                     'deviceId': 'BAD032986065E8DC14CBB6472EC314A6'},
+                     'time': '2022-02-12T02:58:30.765459650Z'}
+        '''
+        payload = {
+            "key": {
+                "request_id": request_id
+            },
+            "device_id": device_id
+        }
+        url = '/api/resources/inventory/v1/DeviceDecommissioningConfig'
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url) + ' ' + str(payload))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+
+    def device_decommissioning_status_get_one(self, request_id):
+        ''' Get the decommission status of a device using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+            Args:
+                request_id (string): key identifies the request to decommission the device
+            Returns:
+                response (dict): A dict that contains...
+                Ex:{"result":{"value":{"key":{"requestId":"123456789"},
+                  "status":"DECOMMISSIONING_STATUS_IN_PROGRESS",
+                  "statusMessage":"Disabled TerminAttr, waiting for device to be marked inactive"},
+                  "time":"2022-02-04T19:41:46.376310308Z","type":"INITIAL"}}
+        '''
+        params = 'key.requestId={}'.format(request_id)
+        url = '/api/resources/inventory/v1/DeviceDecommissioning?' + params
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url))
+        return self.clnt.get(url, timeout=self.request_timeout)
+
+    def device_decommissioning_status_get_all(self, status="DECOMMISSIONING_STATUS_UNSPECIFIED"):
+        ''' Get the decommissioning status of all devices using Resource APIs.
+            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+            Args:
+                status (enum): By default it will get the decommissioning status for all devices.
+                    Possible values:
+                        "DECOMMISSIONING_STATUS_UNSPECIFIED" or 0,
+                        "DECOMMISSIONING_STATUS_IN_PROGRESS" or 1,
+                        "DECOMMISSIONING_STATUS_FAILURE" or 2,
+                        "DECOMMISSIONING_STATUS_SUCCESS" or 3
+            Returns:
+                response (dict): A dict that contains...
+                Ex: {"result":{"value":{"key":{"requestId":"123456789"},
+                "status":"DECOMMISSIONING_STATUS_IN_PROGRESS",
+                "statusMessage":"Disabled TerminAttr, waiting for device to be marked inactive"},
+                "time":"2022-02-04T19:41:46.376310308Z","type":"INITIAL"}}
+        '''
+        payload = {
+            "partialEqFilter": [
+                {
+                    "status": status,
+                }
+            ]
+        }
+        url = '/api/resources/inventory/v1/DeviceDecommissioning/all'
+        # For on-prem check the version as it is only supported from 2021.3.0+
+        if not self.clnt.is_cvaas:
+            if self.clnt.apiversion is None:
+                self.get_cvp_info()
+            if self.clnt.apiversion < 7.0:
+                self.log.warning(
+                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                return None
+        self.log.debug('v7 ' + str(url))
+        return self.clnt.post(url, data=payload, timeout=self.request_timeout)

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3681,13 +3681,13 @@ class CvpApi(object):
                      "time":"2021-12-23T02:06:18.739965204Z"}
         '''
         payload = {
-                "key": {
-                    "id": cc_id
-                },
-                "schedule": {
-                    "value": schedule_time,
-                    "notes": notes
-                }
+            "key": {
+                "id": cc_id
+            },
+            "schedule": {
+                "value": schedule_time,
+                "notes": notes
+            }
         }
         cc_url = '/api/resources/changecontrol/v1/ChangeControlConfig'
         # For on-prem check the version as it is only supported from 2022.1.0+
@@ -3696,7 +3696,7 @@ class CvpApi(object):
                 self.get_cvp_info()
             if self.clnt.apiversion < 8.0:
                 self.log.warning(
-                     'Change Control Scheduling via Resource APIs are supported from 2022.1.0 or newer.')
+                    'Change Control Scheduling via Resource APIs are supported from 2022.1.0 or newer.')
                 return None
         self.log.debug('v8 ' + str(cc_url) + ' ' + str(payload))
         return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
@@ -3714,23 +3714,28 @@ class CvpApi(object):
                      'deviceId': 'BAD032986065E8DC14CBB6472EC314A6'},
                      'time': '2022-02-12T02:58:30.765459650Z'}
         '''
-        payload = {
-            "key": {
-                "request_id": request_id
-            },
-            "device_id": device_id
-        }
-        url = '/api/resources/inventory/v1/DeviceDecommissioningConfig'
-        # For on-prem check the version as it is only supported from 2021.3.0+
-        if not self.clnt.is_cvaas:
-            if self.clnt.apiversion is None:
-                self.get_cvp_info()
-            if self.clnt.apiversion < 7.0:
-                self.log.warning(
-                    'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
-                return None
-        self.log.debug('v7 ' + str(url) + ' ' + str(payload))
-        return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+        device_info = self.get_device_by_serial(device_id)
+        if device_info is not None and 'serialNumber' in device_info:
+            payload = {
+                "key": {
+                    "request_id": request_id
+                },
+                "device_id": device_id
+            }
+            url = '/api/resources/inventory/v1/DeviceDecommissioningConfig'
+            # For on-prem check the version as it is only supported from 2021.3.0+
+            if not self.clnt.is_cvaas:
+                if self.clnt.apiversion is None:
+                    self.get_cvp_info()
+                if self.clnt.apiversion < 7.0:
+                    self.log.warning(
+                        'Decommissioning via Resource APIs are supported from 2021.3.0 or newer.')
+                    return None
+            self.log.debug('v7 ' + str(url) + ' ' + str(payload))
+            return self.clnt.post(url, data=payload, timeout=self.request_timeout)
+        else:
+            self.log.warning('Device with %s serial number does not exist' % device_id)
+            return None
 
     def device_decommissioning_status_get_one(self, request_id):
         ''' Get the decommission status of a device using Resource APIs.

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3667,7 +3667,7 @@ class CvpApi(object):
 
     def change_control_schedule(self, cc_id, schedule_time, notes=""):
         ''' Schedule a Change Control using Resource APIs.
-            Supported versions: CVP 2021.3.0 or newer and CVaaS.
+            Supported versions: CVP 2022.1.0 or newer and CVaaS.
 
             Args:
                 cc_id (string): The ID for the new change control.
@@ -3690,15 +3690,15 @@ class CvpApi(object):
                 }
         }
         cc_url = '/api/resources/changecontrol/v1/ChangeControlConfig'
-        # For on-prem check the version as it is only supported from 2021.2.0+
+        # For on-prem check the version as it is only supported from 2022.1.0+
         if not self.clnt.is_cvaas:
             if self.clnt.apiversion is None:
                 self.get_cvp_info()
-            if self.clnt.apiversion < 7.0:
+            if self.clnt.apiversion < 8.0:
                 self.log.warning(
-                     'Change Control Resource APIs are supported from 2021.2.0 or newer.')
+                     'Change Control Scheduling via Resource APIs are supported from 2022.1.0 or newer.')
                 return None
-        self.log.debug('v7 ' + str(cc_url) + ' ' + str(payload))
+        self.log.debug('v8 ' + str(cc_url) + ' ' + str(payload))
         return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
 
     def device_decommissioning(self, device_id, request_id):

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -114,7 +114,7 @@ class CvpClient(object):
     # Maximum number of times to retry a get or post to the same
     # CVP node.
     NUM_RETRY_REQUESTS = 3
-    LATEST_API_VERSION = 6.0
+    LATEST_API_VERSION = 8.0
 
     def __init__(self, logger='cvprac', syslog=False, filename=None,
                  log_level='INFO'):
@@ -201,7 +201,9 @@ class CvpClient(object):
             For CVP versions 2019.0.0 through 2020.1.0, use api version 3.0
             For CVP versions 2020.1.1 through 2020.2.3, use api version 4.0
             For CVP versions 2020.2.4 through 2021.1.x, use api version 5.0
-            For CVP versions 2021.2.0 and beyond, use api version 6.0
+            For CVP versions 2021.2.x, use api version 6.0
+            For CVP versions 2021.3.x, use api version 7.0
+            For CVP versions 2022.1.0 and beyond, use api version 8.0
 
             Args:
                 version (str): The CVP version in use.
@@ -209,7 +211,9 @@ class CvpClient(object):
         self.version = version
         self.log.info('Version %s', version)
         # Set apiversion to latest available API version for CVaaS
-        # Set apiversion to 6.0 for 2021.2.0 and beyond
+        # Set apiversion to 8.0 for 2022.1.x
+        # Set apiversion to 7.0 for 2021.3.x
+        # Set apiversion to 6.0 for 2021.2.x
         # Set apiversion to 5.0 for 2020.2.4 through 2021.1.x
         # Set apiversion to 4.0 for 2020.1.1 through 2020.2.3
         # Set apiversion to 3.0 for 2019.0.0 through 2020.1.0
@@ -227,7 +231,13 @@ class CvpClient(object):
                               ' Appending 0. Updated Version String - %s',
                               ".".join(version_components))
             full_version = ".".join(version_components)
-            if parse_version(full_version) >= parse_version('2021.2.0'):
+            if parse_version(full_version) >= parse_version('2022.1.0'):
+                self.log.info('Setting API version to v8')
+                self.apiversion = 8.0
+            elif parse_version(full_version) >= parse_version('2021.3.0'):
+                self.log.info('Setting API version to v7')
+                self.apiversion = 7.0
+            elif parse_version(full_version) >= parse_version('2021.2.0'):
                 self.log.info('Setting API version to v6')
                 self.apiversion = 6.0
             elif parse_version(full_version) >= parse_version('2020.2.4'):


### PR DESCRIPTION
Readded the decomm APis after accidentally reverting them and uncommented the CC scheduling APis as now they are supported in 2022.1.0

## How to Test

### Decommissioning APIs

Requires CVP 2021.3.0+/CVaaS

```
request_id = str(uuid.uuid4())
device_id = 'BAD032986065E8DC14CBB6472EC314A6' # serial number of the device

# decomm the device
clnt.api.device_decommissioning(device_id, request_id)

# Result:
# {'value': {'key': {'requestId': 'b8d9f661-735b-4060-bb8f-7c68bd7bafef'}, 'deviceId': 'BAD032986065E8DC14CBB6472EC314A6'}, 'time': '2022-03-23T12:18:43.325917146Z'}

# Get the status of the  decomm request
clnt.api.device_decommissioning_status_get_one(request_id)
# Result:
# {'value': {'key': {'requestId': 'b8d9f661-735b-4060-bb8f-7c68bd7bafef'}, 'status': 'DECOMMISSIONING_STATUS_IN_PROGRESS', 'statusMessage': 'Disabled TerminAttr, waiting for device to be marked inactive'}, 'time': '2022-03-23T12:18:53.503566957Z'}
# {'value': {'key': {'requestId': 'b8d9f661-735b-4060-bb8f-7c68bd7bafef'}, 'status': 'DECOMMISSIONING_STATUS_SUCCESS', 'statusMessage': 'Device decommissioned successfully'}, 'time': '2022-03-23T12:20:48.910033696Z'}

# get the status of all decomm requests
clnt.api.device_decommissioning_status_get_all()
# Result:
# {'data': [{'result': {'value': {'key': {'requestId': '123456789'}, 'status':... }

# Example result when the decomm fails:
# {'value': {'key': {'requestId': '7c79ac10-e1dd-4176-80db-5984eb770a84'}, 'status': 'DECOMMISSIONING_STATUS_FAILURE', 'error': 'Pending/In-progress tasks exist for the device', 'statusMessage': ''}, 'time': '2022-03-23T12:26:16.526649464Z'}
# In case there's a pending task, the task must be first removed to fully decomm the device

```

### Schedule a CC

Requires CVP 2022.1.0+/CVaaS

```
# Generate change control id and change control name
cc_id = str(uuid.uuid4())
name = f"Change_{datetime.now().strftime('%Y%m%d_%H%M%S')}"

# Select the tasks and create a CC where all tasks will be run in parallel
tasks = ["1256","1259","1258","1260"]
clnt.api.change_control_create_for_tasks(cc_id, name, tasks, series=False)

# Schedule the change control
schedule_note = "Scheduling CC via cvprac"
schedule_time = "2022-03-23T12:17:00Z"
clnt.api.change_control_schedule(cc_id,schedule_time,notes=schedule_note)

# Approve the change control
approve_note = "Approving CC via cvprac"
clnt.api.change_control_approve(cc_id, notes=approve_note)

```