### PR TITLE
apis: don't run getConfigletByName for every configlet in get_configl…

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -367,8 +367,8 @@ class CvpApi(object):
         configlets = self.clnt.get('/configlet/getConfiglets.do?'
                                    'startIndex=%d&endIndex=%d' % (start, end),
                                    timeout=self.request_timeout)
-        if self.clnt.apiversion == 1.0:
-            self.log.debug('v1 Inventory API Call')
+        if self.clnt.apiversion == 1.0 or self.clnt.apiversion >= 4.0:
+            self.log.debug('v1/v4+ Inventory API Call')
             return configlets
         else:
             self.log.debug('v2 Inventory API Call')


### PR DESCRIPTION
…ets function

We've noticed that the time it takes to run get_configlets() using go-cvprac vs python cvprac is 40-50x faster, which seems to have been cause by the fact that in python cvprac we were running getConfigletByName for each configlet to populate the configlets content. I've tested this in quite many CVP versions and do not see this issue where the `conifg` key is empty as I mentioned in #190 I made a small changed and ignored doing the `get_configlet_by_name` for v1 and v4+ apiversions (in theory it should be even with v2, but we don't support those older CV version anymore). On my highest scale system I have about 2000 configlets and here are the differences in exec time:

Before

```
time python3 configlet_test.py
python3 configlet_test.py  6.50s user 1.88s system 1% cpu 13:03.20 total
```

After

```
time python3 configlet_test.py
python3 configlet_test.py  0.89s user 0.89s system 9% cpu 18.720 total
```

so that's 783 seconds (13 min 3 sec) vs 18 seconds, quite a big improvement!

used https://github.com/aristanetworks/cvprac/blob/develop/docs/labs/lab03-configlet-management/backup_configlets.py to test the timing

the only configs that would be empty are builders, which are not actually considered configlets as they are python scripts and if someone wants to retrieve the builder contents there are other specific APIs for that