### PR TITLE
Fix: Use status endpoint instead of config endpoint for service account resource APIs

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3875,7 +3875,7 @@ class CvpApi(object):
             return self.clnt.post(url, data=payload)
 
     def svc_account_get_all(self):
-        ''' Get all service account config/status states using Resource APIs.
+        ''' Get all service account states using Resource APIs.
             Supported versions: CVP 2021.3.0 or newer and CVaaS.
             Returns:
                 response (list): Returns a list of dictionaries that contains...
@@ -3891,7 +3891,7 @@ class CvpApi(object):
             return self.clnt.post(url)
 
     def svc_account_get_one(self, username):
-        ''' Get a service account's config/status state using Resource APIs
+        ''' Get a service account's state using Resource APIs
             Supported versions: CVP 2021.3.0 or newer and CVaaS.
             Args:
                 username (string): The service account username.

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3875,7 +3875,7 @@ class CvpApi(object):
             return self.clnt.post(url, data=payload)
 
     def svc_account_get_all(self):
-        ''' Get all service account states using Resource APIs.
+        ''' Get all service account config/status states using Resource APIs.
             Supported versions: CVP 2021.3.0 or newer and CVaaS.
             Returns:
                 response (list): Returns a list of dictionaries that contains...
@@ -3886,12 +3886,12 @@ class CvpApi(object):
         '''
         msg = 'Service Account Resource APIs are supported from 2021.3.0+.'
         if self.cvp_version_compare('>=', 7.0, msg):
-            url = '/api/v3/services/arista.serviceaccount.v1.AccountConfigService/GetAll'
+            url = '/api/v3/services/arista.serviceaccount.v1.AccountService/GetAll'
             self.log.debug('v7 {} '.format(url))
             return self.clnt.post(url)
 
     def svc_account_get_one(self, username):
-        ''' Get a service account's state using Resource APIs
+        ''' Get a service account's config/status state using Resource APIs
             Supported versions: CVP 2021.3.0 or newer and CVaaS.
             Args:
                 username (string): The service account username.
@@ -3904,7 +3904,7 @@ class CvpApi(object):
         msg = 'Service Account Resource APIs are supported from 2021.3.0+.'
         if self.cvp_version_compare('>=', 7.0, msg):
             payload = {"key": {"name": username}}
-            url = '/api/v3/services/arista.serviceaccount.v1.AccountConfigService/GetOne'
+            url = '/api/v3/services/arista.serviceaccount.v1.AccountService/GetOne'
             self.log.debug('v7 {} {}'.format(url, payload))
             return self.clnt.post(url, data=payload)
 

--- a/docs/labs/lab07-aaa/delete_svc_account_created_by_user.py
+++ b/docs/labs/lab07-aaa/delete_svc_account_created_by_user.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the COPYING file.
+
+from cvprac.cvp_client import CvpClient
+from cvprac.cvp_client_errors import CvpApiError
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+
+# Create connection to CloudVision using user/password (on-prem only)
+clnt = CvpClient()
+clnt.connect(['cvp1'],'username', 'password')
+
+svc_accounts = clnt.api.svc_account_get_all()
+created_by = 'john.smith'
+
+# Delete service accounts created by user john.smith
+for account in svc_accounts:
+    if account['value']['created_by'] == created_by:
+        acc_to_delete = account
+        clnt.api.svc_account_delete(acc_to_delete['value']['key']['name'])

--- a/docs/labs/lab07-aaa/delete_svc_account_created_by_user.py
+++ b/docs/labs/lab07-aaa/delete_svc_account_created_by_user.py
@@ -19,5 +19,4 @@ created_by = 'john.smith'
 # Delete service accounts created by user john.smith
 for account in svc_accounts:
     if account['value']['created_by'] == created_by:
-        acc_to_delete = account
-        clnt.api.svc_account_delete(acc_to_delete['value']['key']['name'])
+        clnt.api.svc_account_delete(account['value']['key']['name'])

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -247,6 +247,9 @@ class TestCvpClient(TestCvpClientBase):
                 self.assertIn('value', result[0])
                 self.assertIn('key', result[0]['value'])
                 self.assertIn('name', result[0]['value']['key'])
+                self.assertIn('status', result[0]['value'])
+                self.assertIn('created_by', result[0]['value'])
+                self.assertIn('last_access', result[0]['value'])
                 self.assertEqual(result[0]['value']['key']['name'], username)
                 initial_acc_status = result[0]['value']['status']
                 initial_groups = result[0]['value']['groups']['values']
@@ -278,6 +281,11 @@ class TestCvpClient(TestCvpClientBase):
 
             # Test Get all service account with new account
             result = self.api.svc_account_get_all()
+            self.assertIn('value', result[0])
+            self.assertIn('key', result[0]['value'])
+            self.assertIn('name', result[0]['value']['key'])
+            self.assertIn('created_by', result[0]['value'])
+            self.assertIn('last_access', result[0]['value'])
             self.assertIsNotNone(result)
             self.assertEqual(len(result), start_total + 1)
 


### PR DESCRIPTION
Fixes #234 

Change `svc_account_get_one` and `svc_account_get_all` to use the status endpoints instead of the config endpoints

`AccountService/GetOne` and `AccountService/GetAll` instead of `AccountConfigeService/GetOne` and `AccountConfigService/GetAll`

this will gain us two extra key values:
- `created_by`: the user that created the service account
- `last_access`: the last time the service account accessed the system

this change should be transparent for users who've used these functions before as the return data has the same format + those 2 k,v pairs

- added system test as well to check for those 2 new keys