### PR TITLE
add socks5 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests>=1.0.0'],
+    install_requires=['requests[socks]>=1.0.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
When you don't have https access to cvp but have ssh.

Start a terminal session
```bash
#ssh -l <cvp_shell_user> <cvp_ip> -D 8080 -N
```
Then in a new window:
```bash
#export HTTPS_PROXY='socks5h://127.0.0.1:8080'
#export HTTP_PROXY='socks5h://127.0.0.1:8080'
#python3 ./my_cvprac_program.py
```

