### PR TITLE
Refactor: Handling - "if get_parent_container_for_device() returns None" inside reset_device()

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2893,10 +2893,15 @@ class CvpApi(object):
                 % (app_name, device['fqdn']))
         self.log.debug(info)
 
-        parent_cont = self.get_parent_container_for_device(device['key'])
-        # it will throw error if get_parent_container_for_device() returns None, need to handle this
-        from_id = parent_cont['key']
-
+        if 'parentContainerId' in device:
+            from_id = device['parentContainerId']
+        else:
+            parent_cont = self.get_parent_container_for_device(device['key'])
+            if parent_cont and 'key' in parent_cont:
+                from_id = parent_cont['key']
+            else:
+                from_id = ''
+                
         data = {'data': [{'info': info,
                           'infoPreview': info,
                           'action': 'reset',

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2892,11 +2892,11 @@ class CvpApi(object):
         info = ('App %s reseting device %s and moving it to Undefined'
                 % (app_name, device['fqdn']))
         self.log.debug(info)
-        if 'parentContainerId' in device:
-            from_id = device['parentContainerId']
-        else:
-            parent_cont = self.get_parent_container_for_device(device['key'])
-            from_id = parent_cont['key']
+
+        parent_cont = self.get_parent_container_for_device(device['key'])
+        # it will throw error if get_parent_container_for_device() returns None, need to handle this
+        from_id = parent_cont['key']
+
         data = {'data': [{'info': info,
                           'infoPreview': info,
                           'action': 'reset',


### PR DESCRIPTION
## Change Summary

Removed the check for 'parentContainerId' from reset_device() method to resolve issue #239 

## Related Issue(s)

Fixes #239  