### PR TITLE
Fix: Add workaround for CVP API validation config

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -1327,15 +1327,31 @@ class CvpApi(object):
                     validation operation
         '''
         if "warnings" not in data:
+            # nothing to do here, we can return as is
             return data
+        # Since there may be warnings incorrectly split on
+        # ', ' within the warning text by CVP, we join all the 
+        # warnings together using ', ' into one large string
         temp_warnings = ", ".join(data['warnings']).strip()
+
+        # To split the large string again we match on the 
+        # 'at line XXX' that should indicate the end of the warning.
+        # We capture as well the remaining \\n or whitespace and include
+        # the extra ', ' added in the previous step in the matching criteria.
+        # The extra ', ' is not included in the strings of the new list
         temp_warnings = split(
-            r'(.*?\\n), ',
+            r'(.*?at line \d+.*?),\s+',
             temp_warnings
         )
+
+        # The behaviour of re.split will add empty strings
+        # if the regex matches on the begging or ending of the lin.
+        # Refer to https://docs.python.org/3/library/re.html#re.split
+
         # Use filter to remove any empty strings
         # that re.split inserted
         data['warnings'] = list(filter(None, temp_warnings))
+        # Update the count of warnings to the correct value
         data['warningCount'] = len(data['warnings'])
         return data
 

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -1345,7 +1345,7 @@ class CvpApi(object):
         )
 
         # The behaviour of re.split will add empty strings
-        # if the regex matches on the begging or ending of the lin.
+        # if the regex matches on the begging or ending of the line.
         # Refer to https://docs.python.org/3/library/re.html#re.split
 
         # Use filter to remove any empty strings

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -690,12 +690,32 @@ class TestCvpClient(TestCvpClientBase):
         result = self.api.validate_config(self.device['key'], config)
         self.assertEqual(result, True)
 
+    def test_api_validate_config_warn(self):
+        ''' Verify config with only warnings returns True
+        '''
+        config = 'interface ethernet1\n description test\nspanning-tree portfast'
+        result = self.api.validate_config(self.device['key'], config)
+        self.assertEqual(result, True)
+
     def test_api_validate_config_error(self):
         ''' Verify an invalid config returns False
         '''
         config = 'interface ethernet1\n typocommand test'
         result = self.api.validate_config(self.device['key'], config)
         self.assertEqual(result, False)
+
+    def test_api_validate_config_device(self):
+        ''' Verify config with only warnings returns True
+        '''
+        config = 'interface ethernet1\n description test\nspanning-tree portfast\n!\nruter bgp something'
+        result = self.api.validate_config_for_device(self.device['key'], config)
+        expected_warning = "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 3"
+        self.assertTrue(expected_warning in result["warnings"][0])
+        self.assertEqual(
+            result['errors'][0]["error"],
+            "> ruter bgp something% Invalid input (at token 0: 'ruter') at line 5",
+        )
+        self.assertEqual(result['warningCount'], 1)
 
     def test_api_get_task_by_id_bad(self):
         ''' Verify get_task_by_id with bad task id

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -1,0 +1,121 @@
+# pylint: disable=wrong-import-position
+#
+# Copyright (c) 2017, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+""" Unit tests for the CvpAPI class
+"""
+import unittest
+from itertools import cycle
+from cvprac.cvp_client import CvpClient
+from cvprac.cvp_api import CvpApi
+
+
+class TestAPI(unittest.TestCase):
+    """Unit test cases for CvpAPI"""
+
+    # pylint: disable=protected-access
+    # pylint: disable=invalid-name
+    # pylint: disable=too-many-statements
+
+    def setUp(self):
+        """Setup for CvpAPI unittests"""
+        self.clnt = CvpClient()
+        nodes = ["1.1.1.1"]
+        self.clnt.nodes = nodes
+        self.clnt.node_cnt = len(nodes)
+        self.clnt.node_pool = cycle(nodes)
+        self.api = CvpApi(self.clnt)
+
+    def test_sanitize_warnings(self):
+        """Test sanitization if warnings are split"""
+        input = {
+            "warnings": [
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs",
+                "concentrators",
+                "switches",
+                "bridges",
+                "etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs",
+                "concentrators",
+                "switches",
+                "bridges",
+                "etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n",
+            ],
+            "warningCount": 10,
+            "errors": [
+                {
+                    "lineNo": " 6",
+                    "error": "> ruter bgp 1512% Invalid input (at token 0: 'ruter') at line 6",
+                }
+            ],
+            "errorCount": 1,
+        }
+        expected = {
+            "warnings": [
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n",
+            ],
+            "warningCount": 3,
+            "errors": [
+                {
+                    "lineNo": " 6",
+                    "error": "> ruter bgp 1512% Invalid input (at token 0: 'ruter') at line 6",
+                }
+            ],
+            "errorCount": 1,
+        }
+        print(self.api.sanitize_warnings(input))
+        assert self.api.sanitize_warnings(input) == expected
+
+    def test_sanitize_warnings_skip(self):
+        """Test sanitization if no warnings need changing"""
+        input = {
+            "result": [
+                {
+                    "output": "enter input line by line; when done enter one or more control-d\n\n> spanning-tree portfast\n! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2\nCopy completed successfully.\n",
+                    "messages": ["Copy completed successfully."],
+                },
+                {
+                    "output": "! Command: show session-configuration named capiVerify-2002-f8a137cac96e11ed89be020000000000\n! device: tp-avd-leaf2 (vEOS-lab, EOS-4.29.1F)\n!\n! boot system flash:/vEOS-lab-4.29.1F.swi\n!\nno aaa root\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice routing protocols model ribd\n!\nspanning-tree mode mstp\n!\ninterface Ethernet1\n   spanning-tree portfast\n!\ninterface Ethernet2\n!\ninterface Ethernet3\n!\ninterface Ethernet4\n!\ninterface Ethernet5\n!\ninterface Management1\n!\nno ip routing\n!\nend\n"
+                },
+            ],
+            "warnings": [
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2"
+            ],
+            "id": "Arista-3-4826123409839743",
+            "warningCount": 1,
+            "jsonrpc": "2.0",
+        }
+        # The result should not change
+        assert self.api.sanitize_warnings(input) == input

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -59,6 +59,7 @@ class TestAPI(unittest.TestCase):
         """Test sanitization if warnings are split"""
         input = {
             "warnings": [
+                "! Change will take effect only after switch reboot at line 11\\n\\n",
                 "! \\nWARNING!\\nChanging TCAM profile will cause forwarding agent(s) to exit and restart.\\nAll traffic through the forwarding chip managed by the restarting\\nforwarding agent will be dropped.\\n at line 392",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs",
                 "concentrators",
@@ -70,9 +71,12 @@ class TestAPI(unittest.TestCase):
                 "switches",
                 "bridges",
                 "etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
-                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n",
+                "! Interface does not exist. The configuration will not take effect until the module is inserted. at line 2799\\n\\n\\n\\n\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 1247\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
+
             ],
-            "warningCount": 11,
+            "warningCount": 14,
             "errors": [
                 {
                     "lineNo": " 6",
@@ -83,12 +87,15 @@ class TestAPI(unittest.TestCase):
         }
         expected = {
             "warnings": [
+                "! Change will take effect only after switch reboot at line 11\\n\\n",
                 "! \\nWARNING!\\nChanging TCAM profile will cause forwarding agent(s) to exit and restart.\\nAll traffic through the forwarding chip managed by the restarting\\nforwarding agent will be dropped.\\n at line 392",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2\\n\\n",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n",
+                "! Interface does not exist. The configuration will not take effect until the module is inserted. at line 2799\\n\\n\\n\\n\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 1247\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
             ],
-            "warningCount": 4,
+            "warningCount": 7,
             "errors": [
                 {
                     "lineNo": " 6",

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -59,6 +59,7 @@ class TestAPI(unittest.TestCase):
         """Test sanitization if warnings are split"""
         input = {
             "warnings": [
+                "! \\nWARNING!\\nChanging TCAM profile will cause forwarding agent(s) to exit and restart.\\nAll traffic through the forwarding chip managed by the restarting\\nforwarding agent will be dropped.\\n at line 392",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs",
                 "concentrators",
                 "switches",
@@ -69,9 +70,9 @@ class TestAPI(unittest.TestCase):
                 "switches",
                 "bridges",
                 "etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
-                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
             ],
-            "warningCount": 10,
+            "warningCount": 11,
             "errors": [
                 {
                     "lineNo": " 6",
@@ -82,11 +83,12 @@ class TestAPI(unittest.TestCase):
         }
         expected = {
             "warnings": [
+                "! \\nWARNING!\\nChanging TCAM profile will cause forwarding agent(s) to exit and restart.\\nAll traffic through the forwarding chip managed by the restarting\\nforwarding agent will be dropped.\\n at line 392",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 2\\n\\n",
                 "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 4\\n",
-                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n",
+                "! portfast should only be enabled on ports connected to a single host. Connecting hubs, concentrators, switches, bridges, etc. to this interface when portfast is enabled can cause temporary bridging loops. Use with CAUTION. at line 6\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n",
             ],
-            "warningCount": 3,
+            "warningCount": 4,
             "errors": [
                 {
                     "lineNo": " 6",
@@ -95,7 +97,6 @@ class TestAPI(unittest.TestCase):
             ],
             "errorCount": 1,
         }
-        print(self.api.sanitize_warnings(input))
         assert self.api.sanitize_warnings(input) == expected
 
     def test_sanitize_warnings_skip(self):


### PR DESCRIPTION
Adds a workaround for the case where CVP API splits warnings over several strings when validating
configuration that has both errors and warnings.

# Changes
- add a sanitization method to cvp_api & pass validation reply through sanitization
- add unittests
- add sytemtests
