### PR TITLE
Feat: add support for config validation during config assign

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -1486,7 +1486,7 @@ class CvpApi(object):
                     via the new_configlets parameter.
                 validate (bool): Defaults to False. If set to True, the function
                     will validate and compare the configlets to be attached and
-                    pupulate the configCompareCount field in the data dict. In case
+                    populate the configCompareCount field in the data dict. In case
                     all keys are 0, ie there is no difference between designed-config
                     and running-config after applying the configlets, no task will be
                     generated.
@@ -1544,14 +1544,11 @@ class CvpApi(object):
                           'parentTask': ''}]}
         if validate:
             validation_result = self.validate_configlets_for_device(dev['systemMacAddress'], ckeys)
-            mismatch_count = validation_result['mismatch']
-            new_count = validation_result['new']
-            reconcile_count = validation_result['reconcile']
             data['data'][0].update({
                 "configCompareCount": {
-                    "mismatch": mismatch_count,
-                    "reconcile": reconcile_count,
-                    "new": new_count
+                    "mismatch": validation_result['mismatch'],
+                    "reconcile": validation_result['reconcile'],
+                    "new": validation_result['new']
                     }
                 }
             )

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -1556,6 +1556,11 @@ class TestCvpClient(TestCvpClientBase):
         self.assertEqual(validate_and_apply['data']['taskIds'], [])
         self.assertEqual(validate_and_apply['data']['status'], 'success')
 
+        # Delete the new configlet
+        param = {'name': new_configlet_name, 'key': new_configlet_data['key']}
+        self.api.remove_configlets_from_device(label, self.device, [param])
+        self.api.delete_configlet(new_configlet_name, new_configlet_data['key'])
+
         # Check compliance
         self.test_api_check_compliance()
 

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -1434,6 +1434,7 @@ class TestCvpClient(TestCvpClientBase):
         ''' Verify apply_configlets_to_device and
             remove_configlets_from_device. Also test apply_configlets_to_device
             with reorder_configlets parameter set to True
+            and test validate parameter set to True
         '''
         # pylint: disable=too-many-statements
         # Create a new configlet
@@ -1531,6 +1532,29 @@ class TestCvpClient(TestCvpClientBase):
 
         # Delete the new configlet
         self.api.delete_configlet(name, key)
+
+        # Test configlet apply with configlet validate and compare
+        # where the designed-config will match the running-config
+        # the result should yield no tasks
+        running_config = self.api.get_device_configuration(self.device['systemMacAddress'])
+
+        # add new configlet and append to the list of configlets
+        new_configlet_name = self.device['fqdn'] + "_rc"
+        self.api.add_configlet(new_configlet_name, running_config)
+        new_configlet_data = self.api.get_configlet_by_name(new_configlet_name)
+
+        # Apply the configlet to the device
+        label = 'cvprac device configlet test with validation'
+        validate_and_apply = self.api.apply_configlets_to_device(
+            label,
+            self.device,
+            [new_configlet_data],
+            validate=True
+        )
+
+        # Check that no taskids have been generated
+        self.assertEqual(validate_and_apply['data']['taskIds'], [])
+        self.assertEqual(validate_and_apply['data']['status'], 'success')
 
         # Check compliance
         self.test_api_check_compliance()


### PR DESCRIPTION
Currently when using `apply_configlets_to_device()` when `create_task=False` we actually just ommit saving topology, like a pre-staging operation, however if there are no diffs between designed-config and running-config, we should just do what the UI does and not generate a task at all by running validateAndCompareConfiglets.do and add `configCompareCount` dict into the addTempAction.do payload. If all keys in that dict, namely `new`, `mismatch` and `reconcile` are 0, the backend will not generate a task.

