### PR TITLE
Feat: add support for config validation during config removal

### DIFF
--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -1558,7 +1558,7 @@ class TestCvpClient(TestCvpClientBase):
 
         # Delete the new configlet
         param = {'name': new_configlet_name, 'key': new_configlet_data['key']}
-        self.api.remove_configlets_from_device(label, self.device, [param])
+        self.api.remove_configlets_from_device(label, self.device, [param], validate=True)
         self.api.delete_configlet(new_configlet_name, new_configlet_data['key'])
 
         # Check compliance


### PR DESCRIPTION
This is the continuation of PR#255 added the same validation on config removal, which avoids generating empty task for no-op changes