### PR TITLE
FIX: Add check to connect() to ensure token works

### DIFF
--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -97,6 +97,7 @@ import logging
 from logging.handlers import SysLogHandler
 from itertools import cycle
 from pkg_resources import parse_version
+
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, \
     ReadTimeout, TooManyRedirects, JSONDecodeError

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -97,7 +97,7 @@ import logging
 from logging.handlers import SysLogHandler
 from itertools import cycle
 from pkg_resources import parse_version
-
+import epdb
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, \
     ReadTimeout, TooManyRedirects, JSONDecodeError
@@ -557,6 +557,7 @@ class CvpClient(object):
         self.headers['APP_SESSION_ID'] = response.json()['sessionId']
 
     def _set_headers_api_token(self):
+        # epdb.serve(port=9999)
         ''' Sets headers with API token instead of making a call to login API.
         '''
         # If using an API token there is no need to run a Login API.
@@ -565,6 +566,19 @@ class CvpClient(object):
         # Alternative to adding token to headers it can be added to
         # cookies as shown below.
         # self.cookies = {'access_token': self.api_token}
+        url = self.url_prefix_short + '/cvpservice/cvpInfo/getCvpInfo.do'
+        # response = self._send_request('GET', url, self.connect_timeout)
+        # response = self.session.get(url,
+                                    # headers=self.headers,
+                                    # timeout=self.connect_timeout,
+                                    # verify=self.cert)
+        response = self.session.get(url,
+                            cookies=self.cookies,
+                            headers=self.headers,
+                            timeout=self.connect_timeout,
+                            verify=self.cert)
+        self._is_good_response(response, 'Authenticate: %s' % url)
+
 
     def logout(self):
         '''

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -97,7 +97,6 @@ import logging
 from logging.handlers import SysLogHandler
 from itertools import cycle
 from pkg_resources import parse_version
-import epdb
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, \
     ReadTimeout, TooManyRedirects, JSONDecodeError
@@ -557,7 +556,6 @@ class CvpClient(object):
         self.headers['APP_SESSION_ID'] = response.json()['sessionId']
 
     def _set_headers_api_token(self):
-        # epdb.serve(port=9999)
         ''' Sets headers with API token instead of making a call to login API.
         '''
         # If using an API token there is no need to run a Login API.
@@ -566,19 +564,14 @@ class CvpClient(object):
         # Alternative to adding token to headers it can be added to
         # cookies as shown below.
         # self.cookies = {'access_token': self.api_token}
-        url = self.url_prefix_short + '/cvpservice/cvpInfo/getCvpInfo.do'
-        # response = self._send_request('GET', url, self.connect_timeout)
-        # response = self.session.get(url,
-                                    # headers=self.headers,
-                                    # timeout=self.connect_timeout,
-                                    # verify=self.cert)
+        url = self.url_prefix_short + '/api/v1/rest'
         response = self.session.get(url,
                             cookies=self.cookies,
                             headers=self.headers,
                             timeout=self.connect_timeout,
                             verify=self.cert)
+        # Verify that the generic request was successful
         self._is_good_response(response, 'Authenticate: %s' % url)
-
 
     def logout(self):
         '''

--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -564,7 +564,7 @@ class CvpClient(object):
         # Alternative to adding token to headers it can be added to
         # cookies as shown below.
         # self.cookies = {'access_token': self.api_token}
-        url = self.url_prefix_short + '/api/v1/rest'
+        url = self.url_prefix_short + '/api/v1/rest/'
         response = self.session.get(url,
                             cookies=self.cookies,
                             headers=self.headers,

--- a/test/fixtures/cvp_nodes.yaml
+++ b/test/fixtures/cvp_nodes.yaml
@@ -10,3 +10,7 @@
   username: CvpRacTest
   password: AristaInnovates
   device: python-test-2
+  # The below fields can be definded to test the token test cases.
+  # If they are undefined, the tests are skipped
+  # api_token: <token here>
+  # api_token_expired: <expired token here>

--- a/test/fixtures/cvp_nodes.yaml
+++ b/test/fixtures/cvp_nodes.yaml
@@ -10,7 +10,7 @@
   username: CvpRacTest
   password: AristaInnovates
   device: python-test-2
-  # The below fields can be definded to test the token test cases.
+  # The below fields can be defined to test the token test cases.
   # If they are undefined, the tests are skipped
   # api_token: <token here>
   # api_token_expired: <expired token here>

--- a/test/system/test_cvp_client.py
+++ b/test/system/test_cvp_client.py
@@ -498,4 +498,4 @@ class TestCvpClient(DutSystemTest):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=3)
+    unittest.main()

--- a/test/system/test_cvp_client.py
+++ b/test/system/test_cvp_client.py
@@ -47,7 +47,6 @@ import unittest
 from pprint import pprint
 from requests.exceptions import Timeout
 sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 from systestlib import DutSystemTest
 from cvprac.cvp_client import CvpClient
 from cvprac.cvp_client_errors import CvpApiError, CvpLoginError, \

--- a/test/system/test_cvp_client.py
+++ b/test/system/test_cvp_client.py
@@ -47,6 +47,7 @@ import unittest
 from pprint import pprint
 from requests.exceptions import Timeout
 sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 from systestlib import DutSystemTest
 from cvprac.cvp_client import CvpClient
 from cvprac.cvp_client_errors import CvpApiError, CvpLoginError, \
@@ -151,6 +152,15 @@ class TestCvpClient(DutSystemTest):
         dut = self.duts[0]
         self.clnt.connect([dut['node']], dut['username'], dut['password'])
 
+    def test_connect_token_good(self):
+        ''' Verify https connection succeeds to a single CVP node
+            Uses https protocol and port with a valid token.
+        '''
+        dut = self.duts[0]
+        if 'api_token' not in dut:
+            raise unittest.SkipTest('No API token found for DUT. Skipping test.')
+        self.clnt.connect([dut['node']], dut['username'], dut['password'], api_token=dut['api_token'])
+
     def test_connect_set_request_timeout(self):
         ''' Verify API request timeout is set when provided to
             client connect method.
@@ -173,6 +183,22 @@ class TestCvpClient(DutSystemTest):
         dut = self.duts[0]
         with self.assertRaises(CvpLoginError):
             self.clnt.connect([dut['node']], dut['username'], 'password')
+
+    def test_connect_token_bad(self):
+        ''' Verify connect fails with bad token.
+        '''
+        dut = self.duts[0]
+        with self.assertRaises(CvpLoginError):
+            self.clnt.connect([dut['node']], dut['username'], 'password', api_token='bad_token')
+
+    def test_connect_token_expired(self):
+        ''' Verify connect fails with an expired token.
+        '''
+        dut = self.duts[0]
+        if 'expired_api_token' not in dut:
+            raise unittest.SkipTest('No Expired token given. Skipping test.')
+        with self.assertRaises(CvpLoginError):
+            self.clnt.connect([dut['node']], dut['username'], 'password', api_token=dut['api_token_expired'])
 
     def test_connect_node_bad(self):
         ''' Verify connection fails to a single bogus CVP node
@@ -473,4 +499,4 @@ class TestCvpClient(DutSystemTest):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=3)


### PR DESCRIPTION
# Summary
At the moment, cvprac does not do any validation during `connect()` if `api_token` is given.

# Tickets
- Currently impacts the `ansible-cvp` collection : https://github.com/aristanetworks/ansible-cvp/issues/675

# Impact. 
`connect()` does not raise any error for invalid, expired or incorrect token. Thus upstream packages are assuming tokens are valid, leading to errors down the line.

# Workaround
None

# Fix
- Added a request to the cvpInfo that should only return 200 if the token is valid and working.
- Added system tests