### PR TITLE
Refactor: Move from pkg_resources to packaging

### DIFF
--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -96,7 +96,7 @@ import json
 import logging
 from logging.handlers import SysLogHandler
 from itertools import cycle
-from pkg_resources import parse_version
+from packaging.version import parse
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, \
@@ -233,28 +233,28 @@ class CvpClient(object):
                               ' Appending 0. Updated Version String - %s',
                               ".".join(version_components))
             full_version = ".".join(version_components)
-            if parse_version(full_version) >= parse_version('2023.1.0'):
+            if parse(full_version) >= parse('2023.1.0'):
                 self.log.info('Setting API version to v9')
                 self.apiversion = 9.0
-            elif parse_version(full_version) >= parse_version('2022.1.0'):
+            elif parse(full_version) >= parse('2022.1.0'):
                 self.log.info('Setting API version to v8')
                 self.apiversion = 8.0
-            elif parse_version(full_version) >= parse_version('2021.3.0'):
+            elif parse(full_version) >= parse('2021.3.0'):
                 self.log.info('Setting API version to v7')
                 self.apiversion = 7.0
-            elif parse_version(full_version) >= parse_version('2021.2.0'):
+            elif parse(full_version) >= parse('2021.2.0'):
                 self.log.info('Setting API version to v6')
                 self.apiversion = 6.0
-            elif parse_version(full_version) >= parse_version('2020.2.4'):
+            elif parse(full_version) >= parse('2020.2.4'):
                 self.log.info('Setting API version to v5')
                 self.apiversion = 5.0
-            elif parse_version(full_version) >= parse_version('2020.1.1'):
+            elif parse(full_version) >= parse('2020.1.1'):
                 self.log.info('Setting API version to v4')
                 self.apiversion = 4.0
-            elif parse_version(full_version) >= parse_version('2019.0.0'):
+            elif parse(full_version) >= parse('2019.0.0'):
                 self.log.info('Setting API version to v3')
                 self.apiversion = 3.0
-            elif parse_version(full_version) >= parse_version('2018.2.0'):
+            elif parse(full_version) >= parse('2018.2.0'):
                 self.log.info('Setting API version to v2')
                 self.apiversion = 2.0
             else:

--- a/docs/labs/lab06-provisioning/vc_task_retrigger.py
+++ b/docs/labs/lab06-provisioning/vc_task_retrigger.py
@@ -7,7 +7,7 @@
 import argparse
 import ssl
 import sys
-from pkg_resources import parse_version
+from packaging.version import parse
 from getpass import getpass
 from cvprac.cvp_client import CvpClient
 import requests.packages.urllib3
@@ -56,7 +56,7 @@ def main():
 
         # Get the current CVP version
         cvp_release = clnt.api.get_cvp_info()['version']
-        if parse_version(cvp_release) < parse_version('2020.3.0'):
+        if parse(cvp_release) < parse('2020.3.0'):
             # For older CVP, we manually trigger a compliance check
             try:
                 clnt.api.check_compliance('root', 'container')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests[socks]>=2.27.0
+packaging>=23.2

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -54,7 +54,7 @@ import sys
 import time
 import unittest
 import uuid
-from pkg_resources import parse_version
+from packaging.version import parse
 from pprint import pprint
 import urllib3
 from test_cvp_base import TestCvpClientBase
@@ -727,7 +727,7 @@ class TestCvpClient(TestCvpClientBase):
         self.assertTrue(expected_warning in result["warnings"][0])
         expected_error = "> ruter bgp something% Invalid input "
         # Error message format changes as of 2021.1.0 or 2021.1.1
-        if parse_version(full_version) >= parse_version("2021.1.0"):
+        if parse(full_version) >= parse("2021.1.0"):
             expected_error += "(at token 0: 'ruter') "
         expected_error += "at line 5"
         self.assertEqual(result['errors'][0]["error"], expected_error)


### PR DESCRIPTION
To support python3.12

```
Python 3.12.0 (main, Oct 25 2023, 09:27:37) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cvprac
>>> from cvprac.cvp_client import CvpClient
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/tmp/py312/venv/lib/python3.12/site-packages/cvprac/cvp_client.py", line 99, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
>>>
```

https://docs.python.org/3/whatsnew/3.12.html

[gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environments

NOTE: it could have been possible to add setuptools to requirement to continue using pkg_resources but it gives a deprecation warning

```
Python 3.12.0 (main, Oct 25 2023, 09:27:37) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pkg_resources
<stdin>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html