### PR TITLE
Fix: missing url encoding for get_user()

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -220,7 +220,7 @@ class CvpApi(object):
             Args:
                 username (str): username on CVP
         '''
-        return self.clnt.get('/user/getUser.do?userId={}'.format(username),
+        return self.clnt.get('/user/getUser.do?userId={}'.format(qplus(username)),
                              timeout=self.request_timeout)
 
     def get_users(self, query='', start=0, end=0):


### PR DESCRIPTION
We forgot to add URL encoding for the single getUser.do API, we had it for getUsers.do

Before:

we'd get

```
CvpApiError: GET: https://192.0.2.79:443/web/user/getUser.do?userId=bob@abc.com : Request Error: Entity does not exist
```

instead of 

```
CvpApiError: GET: https://192.0.2.79:443/web/user/getUser.do?userId=bob%40abc.com : Request Error: Entity does not exist
```

or an actual response