### PR TITLE
Fix: updating the enrollment endpoint for CVaaS

### DIFF
--- a/cvprac/cvp_client.py
+++ b/cvprac/cvp_client.py
@@ -233,7 +233,16 @@ class CvpClient(object):
                               ' Appending 0. Updated Version String - %s',
                               ".".join(version_components))
             full_version = ".".join(version_components)
-            if parse_version(full_version) >= parse_version('2023.1.0'):
+            if parse_version(full_version) >= parse_version('2024.1.0'):
+                self.log.info('Setting API version to v12')
+                self.apiversion = 12.0
+            elif parse_version(full_version) >= parse_version('2023.3.0'):
+                self.log.info('Setting API version to v11')
+                self.apiversion = 11.0
+            elif parse_version(full_version) >= parse_version('2023.2.0'):
+                self.log.info('Setting API version to v10')
+                self.apiversion = 10.0
+            elif parse_version(full_version) >= parse_version('2023.1.0'):
                 self.log.info('Setting API version to v9')
                 self.apiversion = 9.0
             elif parse_version(full_version) >= parse_version('2022.1.0'):


### PR DESCRIPTION
On CVaaS we're migrating away from the /api/v3/services endpoints and moving everything to resource APIs, as part of one of the phases we've moved the enrollment endpoint from

`/api/v3/services/admin.Enrollment/AddEnrollmentToken`

to

`/api/resources/admin.Enrollment/AddEnrollmentToken`

the payload stayed the same with the exception that the `validFor` key only accepts seconds now, e.g. 86400s (where previously you could do '24h' or '60m';

 we will also migrate on on-prem once we get to 2024.2.0 (we'll do a separate PR for that in a few months)

