### PR TITLE
Fix: add timeout to get_configlets_and_mappers()

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -464,7 +464,8 @@ class CvpApi(object):
         '''
         self.log.debug(
             'get_configlets_and_mappers: getConfigletsAndAssociatedMappers')
-        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do')
+        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do',
+                             timeout=self.request_timeout)
 
     def get_configlet_builder(self, c_id):
         ''' Returns the configlet builder data for the given configlet ID.


### PR DESCRIPTION
Adding timeout option to get_configlets_and_mappers() due to some corner cases where the API call could take more than 30 seconds (default timeout) to return data when the system is busy