### PR TITLE
Fix: Move version that searchTopology V3 was added to CVP 2021.2

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -2012,7 +2012,7 @@ class CvpApi():
         self.log.debug(f"search_topology: query: {query} start: {start} end: {end}")
         if self.clnt.apiversion is None:
             self.get_cvp_info()
-        if self.clnt.apiversion <= 8.0:
+        if self.clnt.apiversion <= 6.0:
             # Original search topology endpoint
             req_url = (f"/provisioning/searchTopology.do?queryParam={qplus(query)}&"
                        f"startIndex={start}&endIndex={end}")


### PR DESCRIPTION
Minor update to move version check for usage of searchTopology V3 to 2021.2