### PR TITLE
Fix: README CVaaS cluster URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ generic in this sense. If you are using the cvaas\_token parameter
 please convert to api\_token because the cvaas\_token parameter will be
 deprecated in the future.
 
-Please note that the correct regional URL where the CVaaS tenant is deployed must be used. The following are the
-cluster URLs used in production:
+Please note that the correct regional URL where the CVaaS tenant is deployed must be used. The following
+are some examples of the cluster URLs used in production, a full list can be found on helpcenter:
 
 | Region | URL |
 |--------|-----|
@@ -192,6 +192,8 @@ cluster URLs used in production:
 !!! Warning
 
     URLs without `www` are not supported.
+
+helpcenter link: https://www.arista.io/help/articles/b3ZlcnZpZXcuQWxsLmRlcGxveW1lbnQ=#Y3ZhYXNEZXBsb3ltZW50-region
 
 ### CVP Version Handling
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ are some examples of the cluster URLs used in production, a full list can be fou
 
     URLs without `www` are not supported.
 
-helpcenter link: https://www.arista.io/help/articles/b3ZlcnZpZXcuQWxsLmRlcGxveW1lbnQ=#Y3ZhYXNEZXBsb3ltZW50-region
+helpcenter link: [helpcenter](https://www.arista.io/help/articles/b3ZlcnZpZXcuQWxsLmRlcGxveW1lbnQ=#Y3ZhYXNEZXBsb3ltZW50-region)
 
 ### CVP Version Handling
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ please convert to api\_token because the cvaas\_token parameter will be
 deprecated in the future.
 
 Please note that the correct regional URL where the CVaaS tenant is deployed must be used. The following
-are some examples of the cluster URLs used in production, a full list can be found on helpcenter:
+are some examples of the cluster URLs used in production, a full list can be found on [helpcenter](https://www.arista.io/help/articles/b3ZlcnZpZXcuQWxsLmRlcGxveW1lbnQ=#Y3ZhYXNEZXBsb3ltZW50-region):
 
 | Region | URL |
 |--------|-----|
@@ -193,7 +193,6 @@ are some examples of the cluster URLs used in production, a full list can be fou
 
     URLs without `www` are not supported.
 
-helpcenter link: [helpcenter](https://www.arista.io/help/articles/b3ZlcnZpZXcuQWxsLmRlcGxveW1lbnQ=#Y3ZhYXNEZXBsb3ltZW50-region)
 
 ### CVP Version Handling
 


### PR DESCRIPTION
Fix CVaaS cluster URLs section in README.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
- [ ] Version Bump



## Effort required on reviewer's end
- [x] Easy
- [ ] Medium
- [ ] Hard

