### PR TITLE
Add check for Validation Errors on Tasks before CC Approval

### DIFF
--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -471,6 +471,22 @@ class CvpApi():
         return self.clnt.post('/task/cancelTask.do', data=data,
                               timeout=self.request_timeout)
 
+    def get_config_diff_for_task(self, task_id):
+        ''' Get the config diff and validation errors for a specific task.
+            Uses the compliance check API to compare designed vs running config.
+
+            Args:
+                task_id (str): The task ID to check.
+
+            Returns:
+                response (list): A list of dicts containing sources, diff, and
+                    error entries. Error entries have error_code, error_msg,
+                    line_num, configlet_name, and config_line_num fields.
+        '''
+        diff_url = '/api/v3/services/compliancecheck.Compliance/GetConfigDiffForTask'
+        return self.clnt.post(diff_url, data={"task_id": str(task_id)},
+                              timeout=self.request_timeout)
+
     def get_configlets(self, start=0, end=0):
         ''' Returns a list of all defined configlets.
 
@@ -3111,6 +3127,10 @@ class CvpApi():
         ''' Approve/Unapprove a change control using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.
 
+            When approving (approve=True), validates that no tasks in the
+            change control have configuration errors. Raises CvpApiError
+            if any task has DEVICEERROR entries from the compliance check.
+
             Args:
               cc_id (str): The ID of the change control.
               notes (str): An optional approval note.
@@ -3129,6 +3149,19 @@ class CvpApi():
         else:
             self.log.error('The version timestamp was not found in the CC status.')
             return None
+
+        if approve:
+            task_errors = self._get_task_errors_from_cc(cc_status)
+            if task_errors:
+                error_details = "; ".join(
+                    f"Task {tid}: {err['error_msg']}"
+                    for tid, err in task_errors
+                )
+                raise CvpApiError(
+                    f"Cannot approve change control {cc_id}. "
+                    f"Tasks have configuration errors: {error_details}"
+                )
+
         payload = {
             "key": {
                 "id": cc_id
@@ -3140,6 +3173,46 @@ class CvpApi():
             "version": version
         }
         return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
+
+    def _get_task_errors_from_cc(self, cc_data):
+        ''' Extract task IDs from a change control and check each for config errors.
+            Make an API call on each task and parse the config diff for errors.
+
+            Args:
+                cc_data (dict): The change control dict from change_control_get_one.
+
+            Returns:
+                errors (list): A list of (task_id, error_dict) tuples for any tasks
+                    with DEVICEERROR entries. Empty list if no errors found.
+                    error_dict example: {
+                            "error_code": "DEVICEERROR",
+                            "error_msg": "> typocommand test % Invalid input (at token 0: 'typocommand')",
+                            "line_num": 50,
+                            "configlet_name": "device-name",
+                            "config_line_num": 54
+                        }
+        '''
+        errors = []
+        stages = (cc_data.get('value', {}).get('change', {})
+                  .get('stages', {}).get('values', {}))
+        for stage in stages.values():
+            action = stage.get('action', {})
+            if action.get('name') == 'task':
+                task_id = (action.get('args', {}).get('values', {})
+                           .get('TaskID'))
+                if task_id:
+                    try:
+                        resp = self.get_config_diff_for_task(task_id)
+                    except Exception as error:
+                        self.log.error(
+                            f"Failed to get config diff for task {task_id}: {error}")
+                        continue
+                    if isinstance(resp, list):
+                        for entry in resp:
+                            err = entry.get('error') if isinstance(entry, dict) else None
+                            if err and err.get('error_code') == 'DEVICEERROR':
+                                errors.append((task_id, err))
+        return errors
 
     def change_control_delete(self, cc_id):
         ''' Delete a pending Change Control using Resource APIs.

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3151,7 +3151,7 @@ class CvpApi():
             return None
 
         if approve:
-            task_errors = self._get_task_errors_from_cc(cc_status)
+            task_errors = self._parse_task_errors_from_cc_data(cc_status)
             if task_errors:
                 error_details = "; ".join(
                     f"Task {tid}: {err['error_msg']}"
@@ -3174,8 +3174,8 @@ class CvpApi():
         }
         return self.clnt.post(cc_url, data=payload, timeout=self.request_timeout)
 
-    def _get_task_errors_from_cc(self, cc_data):
-        ''' Extract task IDs from a change control and check each for config errors.
+    def _parse_task_errors_from_cc_data(self, cc_data):
+        ''' Extract task IDs from a change control data and check each for config errors.
             Make an API call on each task and parse the config diff for errors.
 
             Args:

--- a/cvprac/cvp_api.py
+++ b/cvprac/cvp_api.py
@@ -3074,6 +3074,24 @@ class CvpApi():
             return self.clnt.get(cc_url, timeout=self.request_timeout)
         return None
 
+    def change_control_get_task_errors(self, cc_id):
+        ''' Get task configuration errors for a change control.
+            Supported versions: CVP 2021.2.0 or newer and CVaaS.
+
+            Args:
+               cc_id (str): The ID of the change control.
+
+            Returns:
+                errors (list): A list of (task_id, error_dict) tuples for any tasks
+                    with DEVICEERROR entries. Empty list if no errors found.
+                    Returns None if the change control does not exist or the API
+                    is unsupported.
+        '''
+        cc_status = self.change_control_get_one(cc_id)
+        if cc_status is None:
+            return None
+        return self._parse_task_errors_from_cc_data(cc_status)
+
     def change_control_approval_get_one(self, cc_id, cc_time=None):
         ''' Get the state of a specific Change Control's approve config using Resource APIs.
             Supported versions: CVP 2021.2.0 or newer and CVaaS.

--- a/test/system/test_cvp_base.py
+++ b/test/system/test_cvp_base.py
@@ -13,6 +13,7 @@ import urllib3
 sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 from systestlib import DutSystemTest
 from cvprac.cvp_client import CvpClient
+from cvprac.cvp_client_errors import CvpApiError
 
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -101,7 +102,6 @@ class TestCvpClientBase(DutSystemTest):
         '''
         self.task_id = None
         self.cc_id = str(uuid.uuid4())
-        # self.cc_name = 'test_api_%d %s' % time.time()
         self.cc_name = f'test_api_{time.time()}'
 
     def tearDown(self):
@@ -113,11 +113,31 @@ class TestCvpClientBase(DutSystemTest):
         if chg_ctrl_get_one:
             # Delete CC
             self.delete_change_control(self.cc_id)
-            # Cancel task
-            if self.task_id:
-                task = self.api.get_task_by_id(self.task_id)
-                if task and task['currentTaskName'] != "Cancelled":
-                    self.cancel_task(self.task_id)
+            self.cc_id = None
+        # Cancel task
+        if self.task_id:
+            # Do not attempt to cancel tasks with taskStatus
+            # in following list.
+            ignore_task_status = ["COMPLETED"]
+            # Do not attempt to cancel tasks with currentTaskName
+            # in following list.
+            ignore_current_task_name = ["Cancelled"]
+            task = self.api.get_task_by_id(self.task_id)
+            print("")
+            print(self.task_id)
+            print(task)
+            print(task["taskStatus"])
+            print(task["workOrderState"])
+            print(task["currentTaskName"])
+            if task:
+                if task["currentTaskName"] not in ignore_current_task_name:
+                    if task["taskStatus"] not in ignore_task_status:
+                        try:
+                            self.cancel_task(self.task_id)
+                        except CvpApiError as err:
+                            print(f"Error while trying to cancel task {self.task_id} - {err}")
+                            print(f"Task info - {task}")
+            self.task_id = None
 
     def _get_next_task_id(self):
         ''' Return the next task id.
@@ -146,10 +166,10 @@ class TestCvpClientBase(DutSystemTest):
         configlet = None
         for conf in self.dev_configlets:
             if conf['netElementCount'] == 1:
-                configlet = conf
+                configlet = conf.copy()
                 break
         if configlet is None:
-            configlet = self.dev_configlets[0]
+            configlet = self.dev_configlets[0].copy()
 
         config = configlet['config']
         org_config = config
@@ -184,7 +204,7 @@ class TestCvpClientBase(DutSystemTest):
         err_msg = f'Timeout waiting for task id {task_id} to be created'
         self.assertGreater(cnt, 0, msg=err_msg)
         self.task_id = task_id
-        return task_id, org_config
+        return task_id, org_config, configlet
 
     def _create_task_with_invalid_config(self):
         ''' Create a task by adding an invalid EOS command to a configlet.
@@ -202,10 +222,10 @@ class TestCvpClientBase(DutSystemTest):
         configlet = None
         for conf in self.dev_configlets:
             if conf['netElementCount'] == 1:
-                configlet = conf
+                configlet = conf.copy()
                 break
         if configlet is None:
-            configlet = self.dev_configlets[0]
+            configlet = self.dev_configlets[0].copy()
 
         org_config = configlet['config']
         config = org_config + '\ntypocommand test\n'

--- a/test/system/test_cvp_base.py
+++ b/test/system/test_cvp_base.py
@@ -186,6 +186,49 @@ class TestCvpClientBase(DutSystemTest):
         self.task_id = task_id
         return task_id, org_config
 
+    def _create_task_with_invalid_config(self):
+        ''' Create a task by adding an invalid EOS command to a configlet.
+            The invalid command will cause a DEVICEERROR in the config diff
+            compliance check, which is used to test the task error validation
+            in change_control_approve.
+
+            Returns:
+                (task_id, org_config, configlet)
+                task_id (str): Task ID
+                org_config (str): Original configlet contents for cleanup
+                configlet (dict): The configlet dict for cleanup
+        '''
+        task_id = self._get_next_task_id()
+        configlet = None
+        for conf in self.dev_configlets:
+            if conf['netElementCount'] == 1:
+                configlet = conf
+                break
+        if configlet is None:
+            configlet = self.dev_configlets[0]
+
+        org_config = configlet['config']
+        config = org_config + '\ntypocommand test\n'
+        configlet['config'] = config
+
+        self.api.update_configlet(config, configlet['key'], configlet['name'])
+
+        cnt = 30
+        if self.clnt.apiversion is None:
+            self.api.get_cvp_info()
+        if self.clnt.apiversion >= 2.0:
+            cnt += 30
+        while cnt > 0:
+            time.sleep(1)
+            result = self.api.get_task_by_id(task_id)
+            if result is not None:
+                break
+            cnt -= 1
+        err_msg = f'Timeout waiting for task id {task_id} to be created'
+        self.assertGreater(cnt, 0, msg=err_msg)
+        self.task_id = task_id
+        return task_id, org_config, configlet
+
     def delete_change_control(self, cc_id):
         """ Delete change control
         """

--- a/test/system/test_cvp_base.py
+++ b/test/system/test_cvp_base.py
@@ -123,12 +123,6 @@ class TestCvpClientBase(DutSystemTest):
             # in following list.
             ignore_current_task_name = ["Cancelled"]
             task = self.api.get_task_by_id(self.task_id)
-            print("")
-            print(self.task_id)
-            print(task)
-            print(task["taskStatus"])
-            print(task["workOrderState"])
-            print(task["currentTaskName"])
             if task:
                 if task["currentTaskName"] not in ignore_current_task_name:
                     if task["taskStatus"] not in ignore_task_status:

--- a/test/system/test_cvp_change_control_api.py
+++ b/test/system/test_cvp_change_control_api.py
@@ -804,6 +804,13 @@ class TestCvpClientCC(TestCvpClientBase):
             time.sleep(2)
 
             try:
+                # Verify task errors can be fetched directly from the change control
+                task_errors = self.api.change_control_get_task_errors(self.cc_id)
+                self.assertIsNotNone(task_errors)
+                self.assertGreater(len(task_errors), 0)
+                self.assertEqual(task_errors[0][0], task_id)
+                self.assertEqual(task_errors[0][1]['error_code'], 'DEVICEERROR')
+
                 # Approving should raise CvpApiError due to task config errors
                 with self.assertRaises(CvpApiError) as context:
                     self.approve_change_control()

--- a/test/system/test_cvp_change_control_api.py
+++ b/test/system/test_cvp_change_control_api.py
@@ -106,9 +106,9 @@ class TestCvpClientCC(TestCvpClientBase):
         """
         pprint('CREATING TASKS...')
         # global task_id
-        (task_id, _) = self._create_task()
+        task_id, orig_config, configlet = self._create_task()
         self.task_id = task_id
-        return task_id
+        return task_id, orig_config, configlet
 
     def create_change_control_for_task(self, task_id):
         """ Create change control for tasks
@@ -182,7 +182,7 @@ class TestCvpClientCC(TestCvpClientBase):
             "test_api_change_control_create_for_tasks")
         if self.get_version():
             # Create Task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create change control;
             chg_ctrl = self.create_change_control_for_task(
@@ -246,6 +246,12 @@ class TestCvpClientCC(TestCvpClientBase):
             with self.assertRaises(CvpRequestError):
                 self.get_cc_status(self.cc_id)
 
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
+
     def test_api_change_control_approval_get_one(self):
         """ Verify change_control_approval_get_one
          """
@@ -253,7 +259,7 @@ class TestCvpClientCC(TestCvpClientBase):
             "test_api_change_control_approval_get_one")
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create change control
             self.create_change_control_for_task(
@@ -289,6 +295,12 @@ class TestCvpClientCC(TestCvpClientBase):
             # Cancel Task
             self.cancel_task(task_id)
 
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
+
     def test_api_change_control_approval_get_one_without_approve(self):
         """ Verify change_control_approval_get_one_without_approve
          """
@@ -296,7 +308,7 @@ class TestCvpClientCC(TestCvpClientBase):
             "test_api_change_control_approval_get_one_without_approve")
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create CC
             self.create_change_control_for_task(
@@ -313,6 +325,12 @@ class TestCvpClientCC(TestCvpClientBase):
 
             # Cancel Task
             self.cancel_task(task_id)
+
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
 
     def test_api_change_control_create_for_empty_tasks_list(self):
         """ Verify change_control_create_for_tasks for empty task list
@@ -442,7 +460,7 @@ class TestCvpClientCC(TestCvpClientBase):
         pprint("test_api_change_control_get_one")
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create CC
             self.create_change_control_for_task(
@@ -472,6 +490,12 @@ class TestCvpClientCC(TestCvpClientBase):
 
             # Cancel Task
             self.cancel_task(task_id)
+
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
 
     def test_api_change_control_get_one_without_ccid(self):
         """ Verify change_control_get_one_without_ccid
@@ -519,7 +543,7 @@ class TestCvpClientCC(TestCvpClientBase):
         if self.get_version():
             pprint("CHANGE CONTROL GET ALL...")
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create CC
             self.create_change_control_for_task(
@@ -536,6 +560,12 @@ class TestCvpClientCC(TestCvpClientBase):
 
             # Cancel Task
             self.cancel_task(task_id)
+
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
 
     def test_api_change_control_get_all_without_create_chg_ctrl(self):
         """ Verify change_control_get_all_without_create_chg_ctrl
@@ -557,7 +587,7 @@ class TestCvpClientCC(TestCvpClientBase):
         ids = []
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create CC
             self.create_change_control_for_task(
@@ -585,17 +615,22 @@ class TestCvpClientCC(TestCvpClientBase):
             # Cancel Task
             self.cancel_task(task_id)
 
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
+
     def test_api_change_control_approval_get_all_without_approve(self):
         """ Verify change_control_approval_get_all_without_approve
          """
         pprint("test_api_change_control_approval_get_all_without_approve")
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, orig_config, configlet = self.create_task()
 
             # Create CC
-            self.create_change_control_for_task(
-                task_id)
+            self.create_change_control_for_task(task_id)
 
             ids = []
             pprint("CHANGE CONTROL APPROVAL GET ALL WITHOUT APPROVE...")
@@ -609,6 +644,12 @@ class TestCvpClientCC(TestCvpClientBase):
             self.delete_change_control(self.cc_id)
             # Cancel Task
             self.cancel_task(task_id)
+
+            # Restore the configlet to what it was before the task was created.
+            # Set class task_id for cleanup during test tearDown.
+            self.task_id = self._get_next_task_id()
+            self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
+            time.sleep(2)
 
     def test_api_change_control_create_with_custom_stages(self):
         """ Verify test_api_change_control_create_with_custom_stages
@@ -817,23 +858,14 @@ class TestCvpClientCC(TestCvpClientBase):
                 pprint(f'Caught expected error: {context.exception}')
                 self.assertIn('configuration errors', str(context.exception))
             finally:
-                # Predict the task ID that update_configlet will create for the restore
-                tasks = self.api.get_tasks()
-                restore_task_id = str(int(tasks['data'][0]['workOrderId']) + 1) \
-                    if tasks and tasks.get('data') else None
-                # Restore configlet to original config
-                self.api.update_configlet(org_config, configlet['key'],
-                                          configlet['name'])
-                configlet['config'] = org_config
                 # Delete CC and cancel the original invalid task
                 self.delete_change_control(self.cc_id)
                 self.cancel_task(task_id)
+                # Restore configlet to original config
+                # Set class task_id for cleanup during test tearDown.
+                self.task_id = self._get_next_task_id()
+                self.api.update_configlet(org_config, configlet['key'], configlet['name'])
                 time.sleep(2)
-                # Cancel the restoration task created by update_configlet above
-                if restore_task_id:
-                    restore_task = self.api.get_task_by_id(restore_task_id)
-                    if restore_task and restore_task.get('currentTaskName') != 'Cancelled':
-                        self.cancel_task(restore_task_id)
 
     def test_api_change_control_execute_without_approval(self):
         """ Verify that starting a change control without approving it first
@@ -843,14 +875,7 @@ class TestCvpClientCC(TestCvpClientBase):
         pprint("test_api_change_control_execute_without_approval")
         if self.get_version():
             # Create task
-            task_id, org_config = self._create_task()
-            configlet = None
-            for conf in self.dev_configlets:
-                if conf['netElementCount'] == 1:
-                    configlet = conf
-                    break
-            if configlet is None:
-                configlet = self.dev_configlets[0]
+            task_id, orig_config, configlet = self.create_task()
 
             # Create change control but do NOT approve it
             self.create_change_control_for_task(task_id)
@@ -858,26 +883,21 @@ class TestCvpClientCC(TestCvpClientBase):
 
             try:
                 # Starting without approval should raise CvpRequestError
-                with self.assertRaises(CvpRequestError):
+                with self.assertRaises(CvpRequestError) as context:
                     self.start_change_control(self.cc_id)
+                pprint(f'Caught expected error: {context.exception}')
             finally:
-                # Predict the task ID that update_configlet will create for the restore
-                tasks = self.api.get_tasks()
-                restore_task_id = str(int(tasks['data'][0]['workOrderId']) + 1) \
-                    if tasks and tasks.get('data') else None
-                # Restore configlet to original config
-                self.api.update_configlet(org_config, configlet['key'],
-                                          configlet['name'])
-                configlet['config'] = org_config
-                # Delete CC and cancel the original task
+                # Delete CC
                 self.delete_change_control(self.cc_id)
+
+                # Cancel Task
                 self.cancel_task(task_id)
+
+                # Restore the configlet to what it was before the task was created.
+                # Set class task_id for cleanup during test tearDown.
+                self.task_id = self._get_next_task_id()
+                self.api.update_configlet(orig_config, configlet['key'], configlet['name'])
                 time.sleep(2)
-                # Cancel the restoration task created by update_configlet above
-                if restore_task_id:
-                    restore_task = self.api.get_task_by_id(restore_task_id)
-                    if restore_task and restore_task.get('currentTaskName') != 'Cancelled':
-                        self.cancel_task(restore_task_id)
 
 
 if __name__ == '__main__':

--- a/test/system/test_cvp_change_control_api.py
+++ b/test/system/test_cvp_change_control_api.py
@@ -824,6 +824,7 @@ class TestCvpClientCC(TestCvpClientBase):
                 # Restore configlet to original config
                 self.api.update_configlet(org_config, configlet['key'],
                                           configlet['name'])
+                configlet['config'] = org_config
                 # Delete CC and cancel the original invalid task
                 self.delete_change_control(self.cc_id)
                 self.cancel_task(task_id)
@@ -867,6 +868,7 @@ class TestCvpClientCC(TestCvpClientBase):
                 # Restore configlet to original config
                 self.api.update_configlet(org_config, configlet['key'],
                                           configlet['name'])
+                configlet['config'] = org_config
                 # Delete CC and cancel the original task
                 self.delete_change_control(self.cc_id)
                 self.cancel_task(task_id)

--- a/test/system/test_cvp_change_control_api.py
+++ b/test/system/test_cvp_change_control_api.py
@@ -820,6 +820,7 @@ class TestCvpClientCC(TestCvpClientBase):
                 # Delete CC and cancel the original invalid task
                 self.delete_change_control(self.cc_id)
                 self.cancel_task(task_id)
+                time.sleep(2)
                 # Cancel the restoration task created by update_configlet above
                 if restore_task_id:
                     restore_task = self.api.get_task_by_id(restore_task_id)
@@ -834,15 +835,40 @@ class TestCvpClientCC(TestCvpClientBase):
         pprint("test_api_change_control_execute_without_approval")
         if self.get_version():
             # Create task
-            task_id = self.create_task()
+            task_id, org_config = self._create_task()
+            configlet = None
+            for conf in self.dev_configlets:
+                if conf['netElementCount'] == 1:
+                    configlet = conf
+                    break
+            if configlet is None:
+                configlet = self.dev_configlets[0]
 
             # Create change control but do NOT approve it
             self.create_change_control_for_task(task_id)
             time.sleep(1)
 
-            # Starting without approval should raise CvpRequestError
-            with self.assertRaises(CvpRequestError):
-                self.start_change_control(self.cc_id)
+            try:
+                # Starting without approval should raise CvpRequestError
+                with self.assertRaises(CvpRequestError):
+                    self.start_change_control(self.cc_id)
+            finally:
+                # Predict the task ID that update_configlet will create for the restore
+                tasks = self.api.get_tasks()
+                restore_task_id = str(int(tasks['data'][0]['workOrderId']) + 1) \
+                    if tasks and tasks.get('data') else None
+                # Restore configlet to original config
+                self.api.update_configlet(org_config, configlet['key'],
+                                          configlet['name'])
+                # Delete CC and cancel the original task
+                self.delete_change_control(self.cc_id)
+                self.cancel_task(task_id)
+                time.sleep(2)
+                # Cancel the restoration task created by update_configlet above
+                if restore_task_id:
+                    restore_task = self.api.get_task_by_id(restore_task_id)
+                    if restore_task and restore_task.get('currentTaskName') != 'Cancelled':
+                        self.cancel_task(restore_task_id)
 
 
 if __name__ == '__main__':

--- a/test/system/test_cvp_change_control_api.py
+++ b/test/system/test_cvp_change_control_api.py
@@ -7,7 +7,7 @@ import time
 import unittest
 from test_cvp_base import TestCvpClientBase
 import urllib3
-from cvprac.cvp_client_errors import CvpRequestError
+from cvprac.cvp_client_errors import CvpApiError, CvpRequestError
 urllib3.disable_warnings(
     urllib3.exceptions.InsecureRequestWarning)
 
@@ -787,6 +787,62 @@ class TestCvpClientCC(TestCvpClientBase):
             with self.assertRaises(CvpRequestError):
                 self.api.change_control_create_with_custom_stages(
                     None)
+
+    def test_api_change_control_approve_with_task_errors(self):
+        """ Verify that approving a change control with tasks containing
+            configuration errors raises CvpApiError.
+            This test adds an invalid EOS command to a configlet to create
+            a task with a DEVICEERROR, then verifies that approval is blocked.
+        """
+        pprint("test_api_change_control_approve_with_task_errors")
+        if self.get_version():
+            # Create a task with invalid config that will produce DEVICEERROR
+            task_id, org_config, configlet = self._create_task_with_invalid_config()
+
+            # Create change control for the task
+            self.create_change_control_for_task(task_id)
+            time.sleep(2)
+
+            try:
+                # Approving should raise CvpApiError due to task config errors
+                with self.assertRaises(CvpApiError) as context:
+                    self.approve_change_control()
+                pprint(f'Caught expected error: {context.exception}')
+                self.assertIn('configuration errors', str(context.exception))
+            finally:
+                # Predict the task ID that update_configlet will create for the restore
+                tasks = self.api.get_tasks()
+                restore_task_id = str(int(tasks['data'][0]['workOrderId']) + 1) \
+                    if tasks and tasks.get('data') else None
+                # Restore configlet to original config
+                self.api.update_configlet(org_config, configlet['key'],
+                                          configlet['name'])
+                # Delete CC and cancel the original invalid task
+                self.delete_change_control(self.cc_id)
+                self.cancel_task(task_id)
+                # Cancel the restoration task created by update_configlet above
+                if restore_task_id:
+                    restore_task = self.api.get_task_by_id(restore_task_id)
+                    if restore_task and restore_task.get('currentTaskName') != 'Cancelled':
+                        self.cancel_task(restore_task_id)
+
+    def test_api_change_control_execute_without_approval(self):
+        """ Verify that starting a change control without approving it first
+            is rejected by CVP with a CvpRequestError.
+            This ensures CVP enforces the approval requirement before execution even on API calls.
+        """
+        pprint("test_api_change_control_execute_without_approval")
+        if self.get_version():
+            # Create task
+            task_id = self.create_task()
+
+            # Create change control but do NOT approve it
+            self.create_change_control_for_task(task_id)
+            time.sleep(1)
+
+            # Starting without approval should raise CvpRequestError
+            with self.assertRaises(CvpRequestError):
+                self.start_change_control(self.cc_id)
 
 
 if __name__ == '__main__':

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -643,7 +643,7 @@ class TestCvpClient(TestCvpClientBase):
         ''' Verify get_task_by_id, get_task_by_status, add_note_to_task,
              get_logs_by_id, and cancel_task
         '''
-        (task_id, org_config) = self._create_task()
+        task_id, org_config, configlet = self._create_task()
 
         # Test get_task_by_id
         result = self.api.get_task_by_id(task_id)
@@ -700,13 +700,6 @@ class TestCvpClient(TestCvpClientBase):
 
         # Restore the configlet to what it was before the task was created.
         task_id = self._get_next_task_id()
-        configlet = None
-        for conf in self.dev_configlets:
-            if conf['netElementCount'] == 1:
-                configlet = conf
-                break
-        if configlet is None:
-            configlet = self.dev_configlets[0]
         self.api.update_configlet(org_config, configlet['key'],
                                   configlet['name'])
         time.sleep(2)
@@ -1311,7 +1304,13 @@ class TestCvpClient(TestCvpClientBase):
         ''' Verify execute_task
         '''
         # Create task and execute it
-        (task_id, _) = self._create_task()
+        task_id, org_config, configlet = self._create_task()
+        self._execute_long_running_task(task_id)
+
+        # Restore the configlet to what it was before the task was created.
+        task_id = self._get_next_task_id()
+        self.api.update_configlet(org_config, configlet['key'], configlet['name'])
+        time.sleep(2)
         self._execute_long_running_task(task_id)
 
         # Check compliance

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -2154,21 +2154,30 @@ class TestCvpClient(TestCvpClientBase):
         orig_configlets = self.api.get_configlets_by_device_id(test_dev['key'])
         # delete from inventory
         if self.clnt.apiversion <= 7.0:
+            print(f"  [DEBUG] apiversion <= 7.0, using delete_device")
             self.api.delete_device(test_dev['systemMacAddress'])
             # sleep to allow delete to complete
             time.sleep(1)
         else:
             req_id = str(uuid.uuid4())
+            print(f"  [DEBUG] apiversion > 7.0, using device_decommissioning with req_id={req_id}")
             self.api.device_decommissioning(test_dev['serialNumber'], req_id)
             decomm_status = "DECOMMISSIONING_STATUS_SUCCESS"
             decomm = ""
             decomm_timer = 0
-            while decomm != decomm_status or decomm_timer < 600:
-                decomm = self.api.device_decommissioning_status_get_one(req_id)['value']['status']
+            while decomm != decomm_status and decomm_timer < 600:
+                resp = self.api.device_decommissioning_status_get_one(req_id)
+                decomm = resp['value']['status']
+                print(f"  [DEBUG] decomm_timer={decomm_timer}s, status={decomm}")
+                if decomm == decomm_status:
+                    break
                 time.sleep(10)
                 decomm_timer += 10
+            print(f"  [DEBUG] decommission loop exited: status={decomm}, timer={decomm_timer}s")
         # verify not found in inventory
+        print(f"  [DEBUG] verifying device {test_dev['fqdn']} removed from inventory")
         res = self.api.get_device_by_name(test_dev['fqdn'])
+        print(f"  [DEBUG] get_device_by_name result: {res}")
         self.assertEqual(res, {})
         # add back to inventory
         # Adding test device back to inv started timing out in CVP2021.2.0
@@ -2177,17 +2186,22 @@ class TestCvpClient(TestCvpClientBase):
             self.api.get_cvp_info()
         if self.clnt.apiversion >= 6.0:
             self.api.request_timeout = orig_timeout * 3
+        print(f"  [DEBUG] adding device back: ip={test_dev['ipAddress']}, container={orig_cont['name']}")
         self.api.add_device_to_inventory(test_dev['ipAddress'],
                                          orig_cont['name'],
                                          orig_cont['key'], True)
+        print(f"  [DEBUG] add_device_to_inventory returned")
         # get non connected device count until it is back to equal or less
         # than the original non connected device count
         non_connect_count = self.api.get_non_connected_device_count()
-        for _ in range(3):
+        print(f"  [DEBUG] non_connect_count={non_connect_count}, orig={orig_non_connect_count}")
+        for i in range(3):
             if non_connect_count <= orig_non_connect_count:
                 break
             time.sleep(1)
             non_connect_count = self.api.get_non_connected_device_count()
+            print(f"  [DEBUG] retry {i+1}: non_connect_count={non_connect_count}")
+        print(f"  [DEBUG] calling save_inventory")
         results = self.api.save_inventory()
         # Save Inventory is deprecated for 2018.2 and beyond
         if self.clnt.apiversion == 1.0:
@@ -2204,16 +2218,23 @@ class TestCvpClient(TestCvpClientBase):
         self.assertEqual(re_added_dev['systemMacAddress'],
                          test_dev['systemMacAddress'])
         # apply original configlets back to device
+        print(f"  [DEBUG] applying original configlets back to device")
         results = self.api.apply_configlets_to_device("test_api_inventory",
                                                       test_dev, orig_configlets,
                                                       create_task=True)
+        print(f"  [DEBUG] apply_configlets result: {results}")
         # execute returned task and wait for it to complete
-        self.api.execute_task(results['data']['taskIds'][0])
-        task_status = self.api.get_task_by_id(results['data']['taskIds'][0])
+        task_id = results['data']['taskIds'][0]
+        print(f"  [DEBUG] executing task {task_id}")
+        self.api.execute_task(task_id)
+        task_status = self.api.get_task_by_id(task_id)
+        task_timer = 0
         while task_status['taskStatus'] != 'COMPLETED':
-            task_status = self.api.get_task_by_id(
-                results['data']['taskIds'][0])
+            print(f"  [DEBUG] task {task_id} status={task_status['taskStatus']}, waited {task_timer}s")
+            task_status = self.api.get_task_by_id(task_id)
             time.sleep(1)
+            task_timer += 1
+        print(f"  [DEBUG] task {task_id} COMPLETED after {task_timer}s")
         if self.clnt.apiversion >= 6.0:
             self.api.request_timeout = orig_timeout
 

--- a/test/system/test_cvp_client_api.py
+++ b/test/system/test_cvp_client_api.py
@@ -2154,30 +2154,21 @@ class TestCvpClient(TestCvpClientBase):
         orig_configlets = self.api.get_configlets_by_device_id(test_dev['key'])
         # delete from inventory
         if self.clnt.apiversion <= 7.0:
-            print(f"  [DEBUG] apiversion <= 7.0, using delete_device")
             self.api.delete_device(test_dev['systemMacAddress'])
             # sleep to allow delete to complete
             time.sleep(1)
         else:
             req_id = str(uuid.uuid4())
-            print(f"  [DEBUG] apiversion > 7.0, using device_decommissioning with req_id={req_id}")
             self.api.device_decommissioning(test_dev['serialNumber'], req_id)
             decomm_status = "DECOMMISSIONING_STATUS_SUCCESS"
             decomm = ""
             decomm_timer = 0
-            while decomm != decomm_status and decomm_timer < 600:
-                resp = self.api.device_decommissioning_status_get_one(req_id)
-                decomm = resp['value']['status']
-                print(f"  [DEBUG] decomm_timer={decomm_timer}s, status={decomm}")
-                if decomm == decomm_status:
-                    break
+            while decomm != decomm_status or decomm_timer < 600:
+                decomm = self.api.device_decommissioning_status_get_one(req_id)['value']['status']
                 time.sleep(10)
                 decomm_timer += 10
-            print(f"  [DEBUG] decommission loop exited: status={decomm}, timer={decomm_timer}s")
         # verify not found in inventory
-        print(f"  [DEBUG] verifying device {test_dev['fqdn']} removed from inventory")
         res = self.api.get_device_by_name(test_dev['fqdn'])
-        print(f"  [DEBUG] get_device_by_name result: {res}")
         self.assertEqual(res, {})
         # add back to inventory
         # Adding test device back to inv started timing out in CVP2021.2.0
@@ -2186,22 +2177,17 @@ class TestCvpClient(TestCvpClientBase):
             self.api.get_cvp_info()
         if self.clnt.apiversion >= 6.0:
             self.api.request_timeout = orig_timeout * 3
-        print(f"  [DEBUG] adding device back: ip={test_dev['ipAddress']}, container={orig_cont['name']}")
         self.api.add_device_to_inventory(test_dev['ipAddress'],
                                          orig_cont['name'],
                                          orig_cont['key'], True)
-        print(f"  [DEBUG] add_device_to_inventory returned")
         # get non connected device count until it is back to equal or less
         # than the original non connected device count
         non_connect_count = self.api.get_non_connected_device_count()
-        print(f"  [DEBUG] non_connect_count={non_connect_count}, orig={orig_non_connect_count}")
-        for i in range(3):
+        for _ in range(3):
             if non_connect_count <= orig_non_connect_count:
                 break
             time.sleep(1)
             non_connect_count = self.api.get_non_connected_device_count()
-            print(f"  [DEBUG] retry {i+1}: non_connect_count={non_connect_count}")
-        print(f"  [DEBUG] calling save_inventory")
         results = self.api.save_inventory()
         # Save Inventory is deprecated for 2018.2 and beyond
         if self.clnt.apiversion == 1.0:
@@ -2218,23 +2204,16 @@ class TestCvpClient(TestCvpClientBase):
         self.assertEqual(re_added_dev['systemMacAddress'],
                          test_dev['systemMacAddress'])
         # apply original configlets back to device
-        print(f"  [DEBUG] applying original configlets back to device")
         results = self.api.apply_configlets_to_device("test_api_inventory",
                                                       test_dev, orig_configlets,
                                                       create_task=True)
-        print(f"  [DEBUG] apply_configlets result: {results}")
         # execute returned task and wait for it to complete
-        task_id = results['data']['taskIds'][0]
-        print(f"  [DEBUG] executing task {task_id}")
-        self.api.execute_task(task_id)
-        task_status = self.api.get_task_by_id(task_id)
-        task_timer = 0
+        self.api.execute_task(results['data']['taskIds'][0])
+        task_status = self.api.get_task_by_id(results['data']['taskIds'][0])
         while task_status['taskStatus'] != 'COMPLETED':
-            print(f"  [DEBUG] task {task_id} status={task_status['taskStatus']}, waited {task_timer}s")
-            task_status = self.api.get_task_by_id(task_id)
+            task_status = self.api.get_task_by_id(
+                results['data']['taskIds'][0])
             time.sleep(1)
-            task_timer += 1
-        print(f"  [DEBUG] task {task_id} COMPLETED after {task_timer}s")
         if self.clnt.apiversion >= 6.0:
             self.api.request_timeout = orig_timeout
 

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -176,6 +176,60 @@ class TestAPI(unittest.TestCase):
 
     @patch.object(CvpApi, 'change_control_get_one')
     @patch.object(CvpApi, 'get_config_diff_for_task')
+    def test_change_control_get_task_errors(self, mock_diff, mock_get_one):
+        """Test that change_control_get_task_errors returns task config errors."""
+        self.clnt.apiversion = 6.0
+        cc_id = 'test-cc-id'
+        mock_get_one.return_value = {
+            'value': {
+                'key': {'id': cc_id},
+                'change': {
+                    'name': 'Test CC',
+                    'time': '2021-12-13T21:05:58.813750128Z',
+                    'rootStageId': 'root',
+                    'stages': {'values': {
+                        'root': {'name': 'root', 'rows': {'values': [{'values': ['stage0']}]}},
+                        'stage0': {
+                            'name': 'Update Config',
+                            'action': {
+                                'name': 'task',
+                                'timeout': 3000,
+                                'args': {'values': {'TaskID': '10'}}
+                            }
+                        }
+                    }}
+                }
+            },
+            'time': '2021-12-13T21:05:58.813750128Z'
+        }
+        task_error = {
+            'error_code': 'DEVICEERROR',
+            'error_msg': '> typocommand test % Invalid input',
+            'line_num': 50,
+            'configlet_name': 'test-configlet',
+            'config_line_num': 54
+        }
+        mock_diff.return_value = [
+            {'sources': {'source': []}},
+            {'diff': {'entries': []}},
+            {'error': task_error}
+        ]
+        result = self.api.change_control_get_task_errors(cc_id)
+        self.assertEqual(result, [('10', task_error)])
+        mock_get_one.assert_called_once_with(cc_id)
+        mock_diff.assert_called_once_with('10')
+
+    @patch.object(CvpApi, 'change_control_get_one')
+    def test_change_control_get_task_errors_returns_none_without_cc(self, mock_get_one):
+        """Test that change_control_get_task_errors returns None when the CC is missing."""
+        self.clnt.apiversion = 6.0
+        mock_get_one.return_value = None
+        result = self.api.change_control_get_task_errors('missing-cc-id')
+        self.assertIsNone(result)
+        mock_get_one.assert_called_once_with('missing-cc-id')
+
+    @patch.object(CvpApi, 'change_control_get_one')
+    @patch.object(CvpApi, 'get_config_diff_for_task')
     @patch.object(CvpClient, 'post')
     def test_change_control_approve_skips_validation_on_unapprove(self, mock_post, mock_diff, mock_get_one):
         """Test that unapproving a change control skips task error validation."""

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -35,8 +35,10 @@
 """
 import unittest
 from itertools import cycle
+from unittest.mock import patch
 from cvprac.cvp_client import CvpClient
 from cvprac.cvp_api import CvpApi, sanitize_warnings
+from cvprac.cvp_client_errors import CvpApiError
 
 
 class TestAPI(unittest.TestCase):
@@ -127,3 +129,103 @@ class TestAPI(unittest.TestCase):
         }
         # The result should not change
         self.assertEqual(sanitize_warnings(test_input), test_input)
+
+    @patch.object(CvpApi, 'change_control_get_one')
+    @patch.object(CvpClient, 'post')
+    def test_change_control_approve_raises_on_task_errors(self, mock_post, mock_get_one):
+        """Test that change_control_approve raises CvpApiError when tasks have config errors."""
+        self.clnt.apiversion = 6.0
+        cc_id = 'test-cc-id'
+        mock_get_one.return_value = {
+            'value': {
+                'key': {'id': cc_id},
+                'change': {
+                    'name': 'Test CC',
+                    'time': '2021-12-13T21:05:58.813750128Z',
+                    'rootStageId': 'root',
+                    'stages': {'values': {
+                        'root': {'name': 'root', 'rows': {'values': [{'values': ['stage0']}]}},
+                        'stage0': {
+                            'name': 'Update Config',
+                            'action': {
+                                'name': 'task',
+                                'timeout': 3000,
+                                'args': {'values': {'TaskID': '10'}}
+                            }
+                        }
+                    }}
+                }
+            },
+            'time': '2021-12-13T21:05:58.813750128Z'
+        }
+        mock_post.return_value = [
+            {'sources': {'source': []}},
+            {'diff': {'entries': []}},
+            {'error': {
+                'error_code': 'DEVICEERROR',
+                'error_msg': '> typocommand test % Invalid input',
+                'line_num': 50,
+                'configlet_name': 'test-configlet',
+                'config_line_num': 54
+            }}
+        ]
+        with self.assertRaises(CvpApiError) as context:
+            self.api.change_control_approve(cc_id)
+        self.assertIn('Task 10', str(context.exception))
+        self.assertIn('typocommand', str(context.exception))
+
+    @patch.object(CvpApi, 'change_control_get_one')
+    @patch.object(CvpApi, 'get_config_diff_for_task')
+    @patch.object(CvpClient, 'post')
+    def test_change_control_approve_skips_validation_on_unapprove(self, mock_post, mock_diff, mock_get_one):
+        """Test that unapproving a change control skips task error validation."""
+        self.clnt.apiversion = 6.0
+        cc_id = 'test-cc-id'
+        mock_get_one.return_value = {
+            'value': {
+                'key': {'id': cc_id},
+                'change': {
+                    'name': 'Test CC',
+                    'time': '2021-12-13T21:05:58.813750128Z',
+                    'rootStageId': 'root',
+                    'stages': {'values': {
+                        'root': {'name': 'root', 'rows': {'values': [{'values': ['stage0']}]}},
+                        'stage0': {
+                            'name': 'Update Config',
+                            'action': {
+                                'name': 'task',
+                                'timeout': 3000,
+                                'args': {'values': {'TaskID': '10'}}
+                            }
+                        }
+                    }}
+                }
+            },
+            'time': '2021-12-13T21:05:58.813750128Z'
+        }
+        unapprove_response = {
+            'value': {
+                'key': {'id': cc_id},
+                'approve': {'value': False, 'notes': ''}
+            }
+        }
+        mock_post.return_value = unapprove_response
+        result = self.api.change_control_approve(cc_id, approve=False)
+        self.assertEqual(result, unapprove_response)
+        mock_diff.assert_not_called()
+
+    @patch.object(CvpClient, 'post')
+    def test_get_config_diff_for_task(self, mock_post):
+        """Test get_config_diff_for_task returns the compliance check response."""
+        expected_response = [
+            {'sources': {'source': [{'source_type': 'CONFIG_TYPE_TOMCAT_CONFIGLET', 'key': 'test'}]}},
+            {'diff': {'entries': [{'op': 'NOP', 'a_lineno': 1, 'b_lineno': 1}]}},
+        ]
+        mock_post.return_value = expected_response
+        result = self.api.get_config_diff_for_task('10')
+        self.assertEqual(result, expected_response)
+        mock_post.assert_called_once_with(
+            '/api/v3/services/compliancecheck.Compliance/GetConfigDiffForTask',
+            data={'task_id': '10'},
+            timeout=self.api.request_timeout
+        )


### PR DESCRIPTION
<!-- Ensure that your PR has a descriptive title and that you are marked as the assignee -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
- [ ] Version Bump

## Closes
<!-- Section is optional -->
<!-- Make sure closes are specified in a form GitHub recognises to auto-close issues -->
No ticket raised.


## Description
<!-- Detailed explanation of the changes made. Include the reasons behind these changes and any relevant context. Link any related issues. -->

At the moment, and Approval of a Change Control on CloudVision can go through even if the Tasks have Validation Errors. 
Ideally we want to raise errors to the user if the Tasks have validation errors, so that the change control is not started. We want to surface the errors to the user and avoid approving the change.

Add a new public function called `change_control_get_task_errors(cc_id)` to get the errors on a particular Change Control
Update `change_control_approval_get_one(self, cc_id, cc_time=None)` to check for errors on pending changes.

## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests. -->

- To test this functionality, we need to create a task with an invalid command in the configlet. Then associate the Task to a change control, and attempt to approve it. 
- A system test ( ) has been added to verify this
- Another system test has been added to ensure that unapproved changes cannot be started on CVP. This is more of a regression test in case in the future any behaviour changes. We are currently basing this solution on the assumption that unapproved changes cannot be started, even through API calls. If this behaviour changes, we would need to add logic in cvprac to prevent unapproved changes from starting.

## Impact
<!-- Section is optional -->
<!-- Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour. -->

- All attempts to approve a change control will now first pull all the tasks in the change control and check whether any Configlet Validation errors exist.

## Additional Information
<!-- Section is optional -->
<!-- Any additional information that reviewers should be aware of.) -->

## Effort required on reviewer's end
- [ ] Easy
- [x] Medium
- [ ] Hard

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
